### PR TITLE
change aws account from composer to workflow

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -87,8 +87,8 @@ export class PinBoardStack extends Stack {
 
     const deployBucket = S3.Bucket.fromBucketName(
       thisStack,
-      "composer-dist",
-      "composer-dist"
+      "workflow-dist",
+      "workflow-dist"
     );
 
     // this allows the lambda to query/create AppSync config/secrets

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,7 +1,7 @@
 regions:
   - eu-west-1
 stacks:
-  - flexible
+  - workflow
 deployments:
 
   pinboard-cloudformation:


### PR DESCRIPTION
We decided it makes more sense for PinBoard to reside in the `workflow` AWS account (rather than `composer` where its been sitting so far) because...
- the permissions bucket is there
- since we plan to have a 1:1 relationship between pinboards and workflow items (at least initially) we might want to have the GraphQL schema cover some of the workflow tables too - much easier in the same AWS account