### PR TITLE
PRout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,8 @@
+{
+  "checkpoints": {
+    "PROD": {
+      "url": "https://pinboard.gutools.co.uk/_prout",
+      "overdue": "5M"
+    }
+  }
+}

--- a/GIT_COMMIT_HASH.ts
+++ b/GIT_COMMIT_HASH.ts
@@ -1,0 +1,2 @@
+// this should get overwritten in CI (see ci.sh)
+export const GIT_COMMIT_HASH = "LOCAL";

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -7,10 +7,13 @@ import {getVerifiedUser} from "./panDomainAuth";
 import {userHasPermission} from "./permissionCheck";
 import fs from "fs";
 import {applyAggressiveCaching, applyNoCaching, applyJavascriptContentType} from "./util";
+import {GIT_COMMIT_HASH} from "../../GIT_COMMIT_HASH";
 
 const IS_RUNNING_LOCALLY = !process.env.LAMBDA_TASK_ROOT;
 
 const server = express();
+
+server.get("/_prout", (_, response) => response.send(GIT_COMMIT_HASH));
 
 // generic error handler to catch errors in the various async functions
 server.use((request, response, next) => {

--- a/ci.sh
+++ b/ci.sh
@@ -13,6 +13,10 @@ yarn install
 # generate cloudformation.yaml
 yarn --cwd 'cdk' synth
 
+# write the current GIT hash to GIT_COMMIT_HASH.ts (so it's available at build time - so it gets baked into the artifact)
+GIT_COMMIT_HASH=$(git rev-parse HEAD)
+echo 'export const GIT_COMMIT_HASH = "'$GIT_COMMIT_HASH'";' > GIT_COMMIT_HASH.ts
+
 # build bootstrapping-lambda into a single file
 yarn --cwd 'bootstrapping-lambda' build
 


### PR DESCRIPTION
This PR sets up [PRout](https://github.com/guardian/prout) for this repo.

## Code Changes
- capture GIT commit hash during CI (in `ci.sh`) and write it to `GIT_COMMIT_HASH.ts`
- make it available on a new `/_prout` endpoint
- add a `.prout.json` to configure PRout to use it

## Manual Changes
As per https://github.com/guardian/prout#configuration...
- I've given `prout-bot` write access (so it can set labels on our pull requests)
![image](https://user-images.githubusercontent.com/19289579/101652881-ad980c00-3a36-11eb-8dc0-232c670aa47e.png)
- Added webhook 
![image](https://user-images.githubusercontent.com/19289579/101654100-061bd900-3a38-11eb-82a6-32a1d569a275.png)
- Add RiffRaff hook...
![image](https://user-images.githubusercontent.com/19289579/101654835-da4d2300-3a38-11eb-8a7a-056c7b48eecf.png)
