### PR TITLE
Configure AppSync for workflow-bridge-lambda

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -155,7 +155,7 @@ export class PinBoardStack extends Stack {
       `${workflowBridgeLambdaBasename
         .replace("pinboard-", "")
         .split("-")
-        .join("_")}_datasource`,
+        .join("_")}_ds`,
       pinboardWorkflowBridgeLambda
     );
 

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -17,6 +17,7 @@ type WorkflowStub {
 	id: Float!
 	title: String
 	composerId: String
+  status: String
 }
 
 type ItemConnection {


### PR DESCRIPTION
## What does this change?
Adds to CDK the resolver necessary to query the `workflow-bridge-lambda`, and updates the GraphQL schema to include the query and `WorkflowStub` data type. Depends on https://github.com/guardian/editorial-tools-pinboard/pull/11.

## How to test
Deploy this branch to CODE. Navigate to the AppSync Console in AWS and, using the pinboard CODE API, run the `listPinboards` query. Observe the data you see matches values present in Workflow CODE.

## How can we measure success?
AppSync can query the bridge lambda and return an appropriately shaped response (an array of `WorkflowStub`).

##  Images
![Screenshot 2020-12-18 at 09 34 32](https://user-images.githubusercontent.com/12645938/102626023-47854600-4114-11eb-8aff-478a5e14bafb.png)

