### PR TITLE
Adds emotion

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.7",
+    "@emotion/react": "^11.1.4",
     "apollo-link": "^1.2.14",
     "aws-appsync-auth-link": "^3.0.2",
     "aws-appsync-subscription-link": "^3.0.3",

--- a/client/src/headingPanel.tsx
+++ b/client/src/headingPanel.tsx
@@ -1,5 +1,6 @@
+/** @jsx jsx */
 import React, { PropsWithChildren } from "react";
-
+import { css, jsx } from "@emotion/react";
 interface HeadingPanelProps {
   heading: string;
   clearSelectedPinboard: () => void;
@@ -7,12 +8,16 @@ interface HeadingPanelProps {
 
 export const HeadingPanel = (props: PropsWithChildren<HeadingPanelProps>) => (
   <div
-    style={{
-      backgroundColor: "orange",
-      padding: "5px",
-    }}
+    css={css`
+      background-color: orange;
+      padding: 5px;
+    `}
   >
-    <div style={{ fontWeight: "bold" }}>
+    <div
+      css={css`
+        font-weight: bold;
+      `}
+    >
       <button onClick={props.clearSelectedPinboard}>👈</button>
       {props.heading}
     </div>

--- a/client/src/items.tsx
+++ b/client/src/items.tsx
@@ -1,6 +1,8 @@
+/** @jsx jsx */
 import { Item } from "../../shared/graphql/graphql";
 import React, { useEffect, useRef } from "react";
 import { User } from "../../shared/User";
+import { css, jsx } from "@emotion/react";
 
 interface ItemDisplayProps {
   item: Item;
@@ -13,19 +15,19 @@ const ItemDisplay = ({ item, refForLastItem }: ItemDisplayProps) => {
   return (
     <div
       ref={refForLastItem}
-      style={{
-        borderBottom: "1px solid gray",
-        paddingBottom: "3px",
-        marginBottom: "3px",
-      }}
+      css={css`
+        border-bottom: 1px solid gray;
+        padding-bottom: 3px;
+        margin-bottom: 3px;
+      `}
     >
       <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          fontSize: "80%",
-          color: "lightgray",
-        }}
+        css={css`
+          display: "flex";
+          justify-content: space-between;
+          font-size: 80%;
+          color: lightgray;
+        `}
       >
         <span>{user.firstName}</span>
         <span>
@@ -113,10 +115,10 @@ export const Items = ({
   return (
     <div
       ref={scrollableAreaRef}
-      style={{
-        overflowY: "auto",
-        margin: "5px",
-      }}
+      css={css`
+        overflow-y: auto;
+        margin: 5px;
+      `}
       onScroll={() => isLastItemVisible() && setHasUnread(false)}
     >
       {items.map((item, index) => (

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -1,3 +1,4 @@
+/** @jsx jsx */
 import React, { useEffect, useState } from "react";
 import {
   ApolloError,
@@ -14,6 +15,7 @@ import {
 import { Items } from "./items";
 import { HeadingPanel } from "./headingPanel";
 import { WidgetProps } from "./widget";
+import { css, jsx } from "@emotion/react";
 
 const isEnterKey = (event: React.KeyboardEvent<HTMLElement>) =>
   event.key === "Enter" || event.keyCode === 13;
@@ -130,8 +132,12 @@ export const Pinboard = ({
   );
 
   return !isSelected ? null : (
-    <>
-      <div style={{ flexGrow: 1 }}>
+    <React.Fragment>
+      <div
+        css={css`
+          flex-grow: 1;
+        `}
+      >
         <HeadingPanel
           heading={pinboardData.title || ""}
           clearSelectedPinboard={clearSelectedPinboard}
@@ -150,13 +156,16 @@ export const Pinboard = ({
         />
       )}
       <div
-        style={{
-          display: "flex",
-          margin: "5px",
-        }}
+        css={css`
+          display: "flex";
+          margin: 5px;
+        `}
       >
         <textarea
-          style={{ flexGrow: 1, marginRight: "5px" }}
+          css={css`
+            flex-grow: 1;
+            margin-right: 5px;
+          `}
           placeholder="enter chat message here..."
           rows={2}
           value={newMessage}
@@ -176,6 +185,6 @@ export const Pinboard = ({
           Send
         </button>
       </div>
-    </>
+    </React.Fragment>
   );
 };

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -1,6 +1,9 @@
+/** @jsx jsx */
+
 import { gql, useQuery } from "@apollo/client";
 import React from "react";
 import FuzzySearch from "react-fuzzy";
+import { css, jsx } from "@emotion/react";
 
 import { PinboardData } from "./pinboard";
 
@@ -41,10 +44,10 @@ export const SelectPinboard = ({
 
   return (
     <div
-      style={{
-        overflowY: "auto",
-        margin: "5px",
-      }}
+      css={css`
+        overflow-y: auto;
+        margin: 5px;
+      `}
     >
       {loading && <p>Loading pinboards...</p>}
       <h4>Open pinboards</h4>

--- a/client/src/widget.tsx
+++ b/client/src/widget.tsx
@@ -1,8 +1,11 @@
+/** @jsx jsx */
+import { ApolloError, gql, useQuery } from "@apollo/client";
+import { css, jsx } from "@emotion/react";
 import React, { useEffect, useState } from "react";
+
 import { User } from "../../shared/User";
 import { Pinboard, PinboardData } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
-import { ApolloError, gql, useQuery } from "@apollo/client";
 
 const bottomRight = 10;
 const widgetSize = 50;
@@ -89,74 +92,74 @@ export const Widget = (props: WidgetProps) => {
   return (
     <div>
       <div
-        style={{
-          position: "fixed",
-          zIndex: 99999,
-          bottom: `${bottomRight}px`,
-          right: `${bottomRight}px`,
-          width: `${widgetSize}px`,
-          height: `${widgetSize}px`,
-          borderRadius: `${widgetSize / 2}px`,
-          cursor: "pointer",
-          background: "orange",
-          boxShadow,
-        }}
+        css={css`
+          position: fixed;
+          z-index: 99999;
+          bottom: ${bottomRight}px;
+          right: ${bottomRight}px;
+          width: ${widgetSize}px;
+          height: ${widgetSize}px;
+          border-radius: ${widgetSize / 2}px;
+          cursor: pointer;
+          background: orange;
+          box-shadow: ${boxShadow};
+        `}
         onClick={() => setIsExpanded((previous) => !previous)}
       >
         <div
-          style={{
-            position: "absolute",
-            fontSize: `${widgetSize / 2}px`,
-            top: `${widgetSize / 4}px`,
-            left: `${widgetSize / 4}px`,
-            userSelect: "none",
-          }}
+          css={css`
+            position: absolute;
+            font-size: ${widgetSize / 2}px;
+            top: ${widgetSize / 4}px;
+            left: ${widgetSize / 4}px;
+            user-select: none;
+          `}
         >
           📌
         </div>
         {hasError && (
           <div
-            style={{
-              position: "absolute",
-              fontSize: `${widgetSize / 3}px`,
-              bottom: `-${widgetSize / 16}px`,
-              right: `-${widgetSize / 16}px`,
-              userSelect: "none",
-              textShadow: "0 0 5px black",
-            }}
+            css={css`
+              position: absolute;
+              font-size: ${widgetSize / 3}px;
+              bottom: -${widgetSize / 16}px;
+              right: -${widgetSize / 16}px;
+              user-select: none;
+              text-shadow: 0 0 5px black;
+            `}
           >
             ⚠️
           </div>
         )}
         {hasUnread && (
           <div
-            style={{
-              position: "absolute",
-              fontSize: `${widgetSize / 3}px`,
-              top: `-${widgetSize / 16}px`,
-              userSelect: "none",
-            }}
+            css={css`
+              position: absolute;
+              font-size: ${widgetSize / 3}px;
+              top: -${widgetSize / 16}px;
+              user-select: none;
+            `}
           >
             🔴
           </div>
         )}
       </div>
       <div
-        style={{
-          position: "fixed",
-          zIndex: 99998,
-          background: "white",
-          boxShadow,
-          border: "2px orange solid",
-          width: "250px",
-          height: "calc(100vh - 100px)",
-          bottom: `${bottomRight + widgetSize / 2 - 5}px`,
-          right: `${bottomRight + widgetSize / 2 - 5}px`,
-          display: isExpanded ? "flex" : "none",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          fontFamily: "sans-serif",
-        }}
+        css={css`
+          position: fixed;
+          z-index: 99998;
+          background: white;
+          box-shadow: ${boxShadow};
+          border: 2px orange solid;
+          width: 250px;
+          height: calc(100vh - 100px);
+          bottom: ${bottomRight + widgetSize / 2 - 5}px;
+          right: ${bottomRight + widgetSize / 2 - 5}px;
+          display: ${isExpanded ? "flex" : "none"};
+          flex-direction: column;
+          justify-content: space-between;
+          font-family: sans-serif;
+        `}
       >
         {!selectedPinboardId && (
           <SelectPinboard

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,7 +1489,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1557,6 +1557,71 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@balena/dockerignore/-/dockerignore-1.0.2.tgz#9ffe4726915251e8eb69f44ef3547e0da2c03e0d"
   integrity sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==
+
+"@emotion/cache@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
+  integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.4":
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.1.4.tgz#ddee4247627ff7dd7d0c6ae52f1cfd6b420357d2"
+  integrity sha512-9gkhrW8UjV4IGRnEe4/aGPkUxoGS23aD9Vu6JCGfEDyBYL+nGkkRBoMFGAzCT9qFdyUvQp4UUtErbKWxq/JS4A==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0.tgz#1a61f4f037cf39995c97fc80ebe99abc7b191ca9"
+  integrity sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"
@@ -5306,7 +5371,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9097,6 +9162,11 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@^4.0.3:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.6.tgz#0d8b97b6bc4748bea46f68602b6df27641b3c548"
+  integrity sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg==
 
 subscriptions-transport-ws@0.9.18:
   version "0.9.18"


### PR DESCRIPTION
## What does this change?
Converts styling to use emotion. In this PR, I've simply replaced the `style` prop in the client with emotion's `css` prop. Whether we want to extract these props out into consts, make use of the styled-components syntax, or some other pattern is probably a matter for discussion in the dev team. Additionally, we don't currently use babel in pinboard, so I've set the jsx pragma at the top of each file where we use emotion's `css` prop.

## How to test
Run the application locally and verify that the widget appears as normal.