### PR TITLE
Add encryption property to Item table

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -149,6 +149,7 @@ export class PinBoardStack extends Stack {
           name: "timestamp",
           type: db.AttributeType.NUMBER,
         },
+        encryption: db.TableEncryption.CUSTOMER_MANAGED,
       }
     );
 


### PR DESCRIPTION
## What does this change?
Adds the encryption property to the Item table. By providing `TableEncryption.CUSTOMER_MANAGED` as the value, a key will be automatically defined and become accessible in the stack definition as `pinboardAppsyncItemTable.encryptionKey`.

## How to test
Apply changes to the stack in AWS and observe that a new KMS key resource is created and used to encrypt the Items DynamoDB table.

## How can we measure success?
We have a new KMS resource that is used to encrypt the Items table. Pinboard widget continues to function as expected.

