### PR TITLE
Fix scripts to output parcel errors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "repository": "https://github.com/guardian/editorial-tools-pinboard",
   "scripts": {
-    "watch": "tsc --noEmit --watch & parcel watch parcel-entry.html --global PinBoard 2>&1 | grep -v 'Could not load source file'",
+    "watch": "tsc --noEmit --watch & parcel watch parcel-entry.html --global PinBoard 2>&1 | grep --line-buffered -v 'Could not load source file'",
     "build": "tsc --noEmit && parcel build parcel-entry.html --global PinBoard"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "prettier-write": "prettier --write .",
     "prettier-check": "prettier --check .",
     "lint": "eslint ./**/src/*.ts ./**/src/*.tsx ./cdk/stack.ts",
-    "watch-client": "yarn --cwd 'client' watch 2>&1 | sed -e 's/^/[CLIENT] /' ",
-    "watch-bootstrapping-lambda": "yarn --cwd 'bootstrapping-lambda' watch 2>&1 | sed -e 's/^/[BOOTSTRAPPING-LAMBDA] /'",
-    "watch": "run-p watch-client watch-bootstrapping-lambda"
+    "watch-client": "yarn --cwd 'client' watch 2>&1",
+    "watch-bootstrapping-lambda": "yarn --cwd 'bootstrapping-lambda' watch 2>&1",
+    "watch": "run-p --print-label watch-client watch-bootstrapping-lambda"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "1.19.2",


### PR DESCRIPTION
## What does this change?
The `start` script was not outputting Parcel errors due to the suppression of a multitude of 'could not load source file' warnings which were truncated from `stdout` before the parcel error was reached. This meant that if there was an error in the file on first build, the user would not be aware that the build had not completed.

This PR:
- fixes that issue by adding a `--line-buffered` flag to the `grep` in the client `watch` script to allow output of the parcel error
- changes the root watch script to use `npm-run-all`'s `--print-label` flag rather than the `sed` commands in the individual scripts.