### PR TITLE
remove redundant params to GraphQL subscriptions as cloudforming is broken

### DIFF
--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -45,27 +45,12 @@ type Query {
 
 type Subscription {
   onCreateItem(
-    id: ID
-    message: String
-    payload: AWSJSON
-    timestamp: AWSTimestamp
-    type: String
     pinboardId: String
   ): Item @aws_subscribe(mutations: ["createItem"])
   onDeleteItem(
-    id: ID
-    message: String
-    payload: AWSJSON
-    timestamp: AWSTimestamp
-    type: String
     pinboardId: String
   ): Item @aws_subscribe(mutations: ["deleteItem"])
   onUpdateItem(
-    id: ID
-    message: String
-    payload: AWSJSON
-    timestamp: AWSTimestamp
-    type: String
     pinboardId: String
   ): Item @aws_subscribe(mutations: ["updateItem"])
 }


### PR DESCRIPTION
It appears AWS has introduced a limit on the number of parameters that can be passed to a subscription. This is causing deployments to fail when cloudforming (including `main`)…
![image](https://user-images.githubusercontent.com/19289579/110862246-2bc6b180-82b7-11eb-9d70-0d3d2d202ef0.png)

## What does this change?
...since we only use one parameter currently, this PR removes the others to fix our deployments. 

## How to test
Deploying this to CODE succeeds and doesn't fail like the above.
