### PR TITLE
ensure the lambda steps run after the cloudformation completes during deployment

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -15,6 +15,8 @@ deployments:
   pinboard-bootstrapping-lambda-api:
     dependencies:
       - pinboard-cloudformation
+      - pinboard-workflow-bridge-lambda
+      - pinboard-users-refresher-lambda
     type: aws-lambda
     parameters:
       prefixStack: false


### PR DESCRIPTION
## What does this change?
https://riffraff.gutools.co.uk/deployment/view/6f12bff8-fadc-4341-ab67-83ca6fa9c5cd recently reminded me that all deployment steps ran separately which means the lambda steps could fail if they didn't exist yet (because cloud-formation step hadn't finished).... this PR puts that right.

I've also made the `pinboard-bootstrapping-lambda-api` step dependent on all the others, since that's the thing that serves the PROUT response.

## How to test
Do a deployment to CODE and see the steps run in the desired order. Alternatively paste the YAML into https://riffraff.gutools.co.uk/configuration/validation

## How can we measure success?
No more failed deploys when we introduce new lambdas etc.
