### PR TITLE
prevent CDKMetadata from appearing in CFN

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/guardian/editorial-tools-pinboard",
   "license": "MIT",
   "scripts": {
-    "synth": "cdk synth --app 'npx ts-node cdk.ts' > cloudformation.yaml"
+    "synth": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts' > cloudformation.yaml"
   },
   "devDependencies": {
     "@types/node": "^14.14.7",


### PR DESCRIPTION
CDKMetadata is normally added by default but causes unnecessary executions of CloudFormation deployment step in the riff-raff deploy, even though no real (infrastructure) changes have happened in the cloudformation

see https://awsbloglink.wordpress.com/2019/05/29/en-aws-cdk-metadata/
