### PR TITLE
add `sorted-index` to the Item table, to simplify other things

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -151,13 +151,23 @@ export class PinBoardStack extends Stack {
           name: "id",
           type: db.AttributeType.STRING,
         },
-        sortKey: {
-          name: "timestamp",
-          type: db.AttributeType.NUMBER,
-        },
         encryption: db.TableEncryption.DEFAULT,
       }
     );
+
+    const pinboardItemTableSortedIndexName = "sorted-index";
+
+    pinboardAppsyncItemTable.addGlobalSecondaryIndex({
+      indexName: pinboardItemTableSortedIndexName,
+      partitionKey: {
+        name: "id",
+        type: db.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "timestamp",
+        type: db.AttributeType.NUMBER,
+      },
+    });
 
     const pinboardUserTableBaseName = "pinboard-user-table";
 
@@ -216,6 +226,7 @@ export class PinBoardStack extends Stack {
         {
           "version": "2017-02-28",
           "operation": "Scan",
+          "index": "${pinboardItemTableSortedIndexName}",
           "filter": #if($context.args.filter) $util.transform.toDynamoDBFilterExpression($ctx.args.filter) #else null #end,
         }
       `)


### PR DESCRIPTION
In order to _get_ or _update_ specific items (see ADD PR LINK HERE) one would have to pass the complete composite key (`id` & `timestamp` - because `id` was the partition key and `timestamp` the sort key) which is kinda gross, so in this PR...

- remove `sortKey` from the primary index for the Item table
- add a new 'Global Secondary Index', called `"sorted-index"`, which has the `sortKey` instead
- then use the new GSI for the `listItems` Query etc.