### PR TITLE
receive grid drops

### DIFF
--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -34,6 +34,7 @@ export const AvatarRoundel = ({
       `}
       title={tooltip}
       src={maybeUser?.avatarUrl}
+      draggable={false}
     />
   ) : (
     <span

--- a/client/src/drop.ts
+++ b/client/src/drop.ts
@@ -1,0 +1,35 @@
+import { CSSObject } from "@emotion/react";
+import { palette } from "@guardian/source-foundations";
+import React from "react";
+import { buildPayloadAndType, PayloadAndType } from "./types/PayloadAndType";
+
+export interface IsDropTargetProps {
+  isDropTarget: boolean;
+}
+
+const GRID_DATA_TRANSFER_TYPE = "application/vnd.asset-handle+json";
+
+export const isGridDragEvent = (event: React.DragEvent<HTMLElement>) =>
+  event?.dataTransfer?.types?.includes(GRID_DATA_TRANSFER_TYPE);
+
+export const convertGridDragEventToPayload = (
+  event: React.DragEvent<HTMLElement>
+): PayloadAndType | null => {
+  const { source, sourceType, ...payload } = JSON.parse(
+    event?.dataTransfer?.getData(GRID_DATA_TRANSFER_TYPE)
+  );
+  return buildPayloadAndType(`${source}-${sourceType}`, payload) || null;
+};
+
+export const dropTargetCss: CSSObject = {
+  background: palette.neutral["60"],
+  color: palette.neutral["20"],
+  opacity: "80%",
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  zIndex: 9999999,
+  border: `4px dashed ${palette.neutral["20"]}`,
+};

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -7,6 +7,7 @@ import { agateSans } from "../fontNormaliser";
 import { bottom, boxShadow, floatySize, right } from "./styling";
 import { useGlobalStateContext } from "./globalState";
 import { SvgAlertTriangle } from "@guardian/source-react-components";
+import { dropTargetCss, IsDropTargetProps } from "./drop";
 
 interface FloatyNotificationsBubbleProps {
   presetUnreadNotificationCount: number | undefined;
@@ -36,7 +37,7 @@ const FloatyNotificationsBubble = ({
   </div>
 );
 
-export const Floaty: React.FC = () => {
+export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const {
     presetUnreadNotificationCount,
     isExpanded,
@@ -89,6 +90,7 @@ export const Floaty: React.FC = () => {
       `}
       onClick={() => setIsExpanded(!isExpanded)}
     >
+      {isDropTarget && <div css={{ ...dropTargetCss, borderRadius: "50%" }} />}
       <PinIcon
         css={css`
           position: absolute;

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -13,8 +13,9 @@ import { neutral, space } from "@guardian/source-foundations";
 import { Navigation } from "./navigation";
 import { useGlobalStateContext } from "./globalState";
 import { getTooltipText } from "./util";
+import { dropTargetCss, IsDropTargetProps } from "./drop";
 
-export const Panel: React.FC = () => {
+export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const {
     isExpanded,
@@ -77,6 +78,7 @@ export const Panel: React.FC = () => {
       `}
       ref={panelRef}
     >
+      {isDropTarget && <div css={{ ...dropTargetCss }} />}
       <Navigation
         activeTab={activeTab}
         setActiveTab={setActiveTab}

--- a/client/src/payloadDisplay.tsx
+++ b/client/src/payloadDisplay.tsx
@@ -30,9 +30,14 @@ export const PayloadDisplay = ({
         cursor: pointer;
       `}
       draggable
-      onDragStart={(event) =>
-        event.dataTransfer.setData("URL", payload.embeddableUrl)
-      }
+      onDragStart={(event) => {
+        event.dataTransfer.setData("URL", payload.embeddableUrl);
+        event.dataTransfer.setData(
+          // prevent grid from accepting these as drops, as per https://github.com/guardian/grid/commit/4b72d93eedcbacb4f90680764d468781a72507f5#diff-771b9da876348ce4b4e057e2d8253324c30a8f3db4e434d49b3ce70dbbdb0775R138-R140
+          "application/vnd.mediaservice.kahuna.image",
+          "true"
+        );
+      }}
       onClick={() => {
         window.open(payload.embeddableUrl, "_blank");
       }}


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

In https://github.com/guardian/grid/pull/3705 we expose a new field `application/vnd.asset-handle+json` in the `dataTransfer` of the drag event on grid images & crops - which contains all the same stuff as the `<asset-handle` HTML elements.

## What does this change?
This PR makes the pinboard floaty and panel into drop targets for drag events containing this `application/vnd.asset-handle+json`. On drop, the json is used to call `setPayloadToBeSent` (in a very similar way to what the `Add to 📌` does). 

## How to test
With https://github.com/guardian/grid/pull/3705 deployed to grid TEST and this branch deployed to pinboard CODE... 
Drag anything from grid onto pinboard floaty and/or panel, notice the the overlay to suggest drop target then release to see it set the payload (which can then be sent or discarded as usual).

## How can we measure success?
This was an expected/desirable behaviour during the liveblog pilot, as its sometimes quicker and/or more intuitive.

## Images
![drag](https://user-images.githubusercontent.com/19289579/168646618-6cb2168d-de3f-4141-829e-90a43f1ced58.gif)