### PR TITLE
WIP display grid 'original' images (now labelled explicitly - awaiting design input)

### DIFF
--- a/client/src/payloadDisplay.tsx
+++ b/client/src/payloadDisplay.tsx
@@ -4,13 +4,14 @@ import { PayloadAndType } from "./types/PayloadAndType";
 import { palette, space } from "@guardian/source-foundations";
 import { SvgCross } from "@guardian/source-react-components";
 import { buttonBackground } from "./styling";
+import { agateSans } from "../fontNormaliser";
 
 interface PayloadDisplayProps extends PayloadAndType {
   clearPayloadToBeSent?: () => void;
 }
 
 export const PayloadDisplay = ({
-  // type, TODO consider tweaking display based on type
+  type,
   payload: { thumbnail, embeddableUrl },
   clearPayloadToBeSent,
 }: PayloadDisplayProps) =>
@@ -18,9 +19,11 @@ export const PayloadDisplay = ({
     <div
       css={css`
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
+        align-items: flex-end;
         position: relative;
         padding: ${space[1]}px;
+        padding-bottom: 0;
       `}
     >
       <img // TODO: hover for larger thumbnail
@@ -33,6 +36,15 @@ export const PayloadDisplay = ({
           event.dataTransfer.setData("URL", embeddableUrl)
         }
       />
+      <span
+        css={css`
+          color: ${palette.neutral["20"]};
+          font-family: ${agateSans.xxsmall({ fontWeight: "bold" })};
+        `}
+      >
+        {type === "grid-crop" && "CROP"}
+        {type === "grid-original" && "ORIGINAL"}
+      </span>
       {clearPayloadToBeSent && (
         <div
           css={css`


### PR DESCRIPTION
Co-authored-by: @andrew-nowak 

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
