### PR TITLE
Create grid-bridge-lambda

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -18,6 +18,11 @@
       "compress": "zip"
     },
     {
+      "action": "pinboard-grid-bridge-lambda",
+      "path": "grid-bridge-lambda/dist",
+      "compress": "zip"
+    },
+    {
       "action": "pinboard-users-refresher-lambda",
       "path": "users-refresher-lambda/dist",
       "compress": "zip"

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -165,9 +165,21 @@ type WorkflowStub {
   isNotFound: Boolean
 }
 
-type GridSummary {
+type GridBadgeData {
+  text: String!
+  color: String!
+}
+
+type GridSearchQueryBreakdown {
+  collections: [GridBadgeData!]
+  labels: [GridBadgeData!]
+  restOfSearch: String
+}
+
+type GridSearchSummary {
   total: Int!
   thumbnails: [String!]!
+  queryBreakdown: GridSearchQueryBreakdown
 }
 
 type ItemConnection {
@@ -217,7 +229,7 @@ type Query {
   getPinboardsByIds(ids: [String!]!): [WorkflowStub]
   getPinboardByComposerId(composerId: String!): WorkflowStub
 
-  getGridSearchSummary(apiUrl: String!): GridSummary
+  getGridSearchSummary(apiUrl: String!): GridSearchSummary
 }
 
 type Subscription {
@@ -364,7 +376,7 @@ input TableStringFilterInput {
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -473,7 +485,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "item_table_datasource",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
       #set($input = $ctx.args.input)
       $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
@@ -506,7 +518,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "item_table_datasource",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -640,7 +652,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -678,7 +690,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -812,7 +824,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -857,7 +869,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -897,7 +909,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -937,7 +949,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -971,7 +983,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "listUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -1111,7 +1123,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1132,7 +1144,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1153,7 +1165,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -165,6 +165,11 @@ type WorkflowStub {
   isNotFound: Boolean
 }
 
+type GridSummary {
+  total: Int!
+  thumbnails: [String!]!
+}
+
 type ItemConnection {
   items: [Item]
   nextToken: String
@@ -211,6 +216,8 @@ type Query {
   listPinboards(searchText: String): [WorkflowStub]
   getPinboardsByIds(ids: [String!]!): [WorkflowStub]
   getPinboardByComposerId(composerId: String!): WorkflowStub
+
+  getGridSearchSummary(apiUrl: String!): GridSummary
 }
 
 type Subscription {
@@ -315,6 +322,115 @@ input TableStringFilterInput {
       },
       "Type": "AWS::AppSync::GraphQLSchema",
     },
+    "pinboardappsyncapigridbridgelambdads1C89A823": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "LambdaConfig": Object {
+          "LambdaFunctionArn": Object {
+            "Fn::GetAtt": Array [
+              "pinboardgridbridgelambda79AD9656",
+              "Arn",
+            ],
+          },
+        },
+        "Name": "grid_bridge_lambda_ds",
+        "ServiceRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapigridbridgelambdadsServiceRole186C7FDF",
+            "Arn",
+          ],
+        },
+        "Type": "AWS_LAMBDA",
+      },
+      "Type": "AWS::AppSync::DataSource",
+    },
+    "pinboardappsyncapigridbridgelambdadsQuerygetGridSearchSummaryResolverA1738BE2": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapigridbridgelambdads1C89A823",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "grid_bridge_lambda_ds",
+        "FieldName": "getGridSearchSummary",
+        "Kind": "UNIT",
+        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
+$util.toJson($ctx.result)",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "pinboardappsyncapigridbridgelambdadsServiceRole186C7FDF": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pinboardappsyncapigridbridgelambdadsServiceRoleDefaultPolicy1506B891": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "pinboardgridbridgelambda79AD9656",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pinboardappsyncapigridbridgelambdadsServiceRoleDefaultPolicy1506B891",
+        "Roles": Array [
+          Object {
+            "Ref": "pinboardappsyncapigridbridgelambdadsServiceRole186C7FDF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "pinboardappsyncapiitemtabledatasourceFD08E0E9": Object {
       "Properties": Object {
         "ApiId": Object {
@@ -357,7 +473,7 @@ input TableStringFilterInput {
         "DataSourceName": "item_table_datasource",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
       #set($input = $ctx.args.input)
       $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
@@ -390,7 +506,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "item_table_datasource",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -524,7 +640,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -562,7 +678,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -696,7 +812,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -741,7 +857,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -781,7 +897,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -821,7 +937,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -855,7 +971,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "listUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "RequestMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -995,7 +1111,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1016,7 +1132,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1037,7 +1153,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
+        "ResponseMappingTemplate": "## schema checksum : ab4917590308870b33db33555489a4a5
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1962,6 +2078,168 @@ $util.toJson($ctx.result)",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+    },
+    "pinboardgridbridgelambda79AD9656": Object {
+      "DependsOn": Array [
+        "pinboardgridbridgelambdaServiceRoleDefaultPolicyFB133D07",
+        "pinboardgridbridgelambdaServiceRole33502BD3",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "workflow-dist",
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Ref": "Stack",
+                },
+                "/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/pinboard-grid-bridge-lambda/pinboard-grid-bridge-lambda.zip",
+              ],
+            ],
+          },
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "pinboard",
+            "STACK": Object {
+              "Ref": "Stack",
+            },
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "pinboard-grid-bridge-lambda-",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "pinboardgridbridgelambdaServiceRole33502BD3",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "Timeout": 5,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pinboardgridbridgelambdaServiceRole33502BD3": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pinboardgridbridgelambdaServiceRoleDefaultPolicyFB133D07": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/pinboard/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pinboardgridbridgelambdaServiceRoleDefaultPolicyFB133D07",
+        "Roles": Array [
+          Object {
+            "Ref": "pinboardgridbridgelambdaServiceRole33502BD3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "pinboarditemtable83382753": Object {
       "DeletionPolicy": "Retain",

--- a/grid-bridge-lambda/package.json
+++ b/grid-bridge-lambda/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "grid-bridge-lambda",
+  "version": "1.0.0",
+  "description": "Lambda to transform Grid API endpoints, for ingesting into AppSync",
+  "repository": "https://github.com/guardian/editorial-tools-pinboard",
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "bundle": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js --external:aws-sdk --platform=node",
+    "build": "run-p --print-label type-check bundle",
+    "run-dev": "esbuild run.ts --bundle --minify --outfile=dist/index.js --platform=node && node dist/index.js"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "^3.0.3",
+    "aws-sdk": "^2.840.0"
+  },
+  "dependencies": {
+    "node-fetch": "^3.2.0"
+  }
+}

--- a/grid-bridge-lambda/run.ts
+++ b/grid-bridge-lambda/run.ts
@@ -6,5 +6,6 @@ handler({
       "https://api.media.test.dev-gutools.co.uk/images?q=%23Test1&length=1&orderBy=-uploadTime",
   },
 })
+  .then(JSON.stringify)
   .then(console.log)
   .catch(console.error);

--- a/grid-bridge-lambda/run.ts
+++ b/grid-bridge-lambda/run.ts
@@ -1,0 +1,10 @@
+import { handler } from "./src";
+
+handler({
+  arguments: {
+    apiUrl:
+      "https://api.media.test.dev-gutools.co.uk/images?q=%23Test1&length=1&orderBy=-uploadTime",
+  },
+})
+  .then(console.log)
+  .catch(console.error);

--- a/grid-bridge-lambda/src/index.ts
+++ b/grid-bridge-lambda/src/index.ts
@@ -3,7 +3,7 @@ import {
   pinboardSecretPromiseGetter,
   STAGE,
 } from "../../shared/awsIntegration";
-import type { GridSummary } from "../../shared/graphql/graphql";
+import type { GridSearchSummary } from "../../shared/graphql/graphql";
 
 import { isSearchResponse, SearchResponse } from "./types";
 
@@ -31,7 +31,7 @@ const gridFetch = async (url: string): Promise<SearchResponse> => {
   );
 };
 
-const getSearchSummary = async (url: string): Promise<GridSummary> => {
+const getSearchSummary = async (url: string): Promise<GridSearchSummary> => {
   const parsedUrl = new URL(url);
   const expectedDomain =
     STAGE === "PROD"

--- a/grid-bridge-lambda/src/index.ts
+++ b/grid-bridge-lambda/src/index.ts
@@ -1,0 +1,49 @@
+import fetch from "node-fetch";
+import {
+  pinboardSecretPromiseGetter,
+  STAGE,
+} from "../../shared/awsIntegration";
+import type { GridSummary } from "../../shared/graphql/graphql";
+
+export const handler = async (event: { arguments?: { apiUrl?: string } }) => {
+  if (event.arguments?.apiUrl) {
+    return getSearchSummary(event.arguments.apiUrl);
+  }
+};
+
+const gridFetch = async (url: string) => {
+  const response = await fetch(url, {
+    headers: {
+      "X-Gu-Media-Key": await pinboardSecretPromiseGetter(
+        `grid/${STAGE === "PROD" ? "PROD" : "CODE"}/apiKey`
+      ),
+    },
+  });
+
+  // TODO stricter type
+  return (await response.json()) as any;
+};
+
+const getSearchSummary = async (url: string): Promise<GridSummary> => {
+  const parsedUrl = new URL(url);
+  const expectedDomain =
+    STAGE === "PROD"
+      ? "api.media.gutools.co.uk"
+      : "api.media.test.dev-gutools.co.uk";
+  if (
+    parsedUrl.hostname !== expectedDomain ||
+    parsedUrl.pathname !== "/images"
+  ) {
+    throw new Error("Invalid Grid search API URL");
+  }
+  parsedUrl.searchParams.set("length", "4");
+  const searchResponse = await gridFetch(parsedUrl.href);
+
+  return {
+    total: searchResponse.total,
+    thumbnails: searchResponse.data?.map(
+      (image: any /*TODO stricter type*/) =>
+        image?.data?.thumbnail?.secureUrl || image?.data?.thumbnail?.file
+    ),
+  };
+};

--- a/grid-bridge-lambda/src/index.ts
+++ b/grid-bridge-lambda/src/index.ts
@@ -3,9 +3,17 @@ import {
   pinboardSecretPromiseGetter,
   STAGE,
 } from "../../shared/awsIntegration";
-import type { GridSearchSummary } from "../../shared/graphql/graphql";
+import type {
+  GridSearchQueryBreakdown,
+  GridSearchSummary,
+} from "../../shared/graphql/graphql";
 
-import { isSearchResponse, SearchResponse } from "./types";
+import { isCollectionResponse, isSearchResponse } from "./types";
+
+const gutoolsDomain =
+  STAGE === "PROD" ? "gutools.co.uk" : "test.dev-gutools.co.uk";
+const mediaApiDomain = `api.media.${gutoolsDomain}`;
+const collectionsDomain = `media-collections.${gutoolsDomain}`;
 
 export const handler = async (event: { arguments?: { apiUrl?: string } }) => {
   if (event.arguments?.apiUrl) {
@@ -13,7 +21,7 @@ export const handler = async (event: { arguments?: { apiUrl?: string } }) => {
   }
 };
 
-const gridFetch = async (url: string): Promise<SearchResponse> => {
+const gridFetch = async (url: string): Promise<unknown> => {
   const response = await fetch(url, {
     headers: {
       "X-Gu-Media-Key": await pinboardSecretPromiseGetter(
@@ -22,39 +30,75 @@ const gridFetch = async (url: string): Promise<SearchResponse> => {
     },
   });
 
-  const body = await response.json();
-  if (isSearchResponse(body)) {
-    return body;
-  }
-  throw new Error(
-    "Response from grid was valid JSON, but did not match expected shape."
-  );
+  return await response.json();
 };
 
 const getSearchSummary = async (url: string): Promise<GridSearchSummary> => {
   const parsedUrl = new URL(url);
-  const expectedDomain =
-    STAGE === "PROD"
-      ? "api.media.gutools.co.uk"
-      : "api.media.test.dev-gutools.co.uk";
+
   if (
-    parsedUrl.hostname !== expectedDomain ||
+    parsedUrl.hostname !== mediaApiDomain ||
     parsedUrl.pathname !== "/images"
   ) {
     throw new Error("Invalid Grid search API URL");
   }
   parsedUrl.searchParams.set("length", "4");
-  const searchResponse = await gridFetch(parsedUrl.href);
 
-  const thumbnails = searchResponse.data
+  // Run api calls in parallel
+  const search = gridFetch(parsedUrl.href);
+  const queryBreakdown = breakdownQuery(parsedUrl.searchParams.get("q"));
+
+  const searchResponse = await search;
+
+  if (!isSearchResponse(searchResponse)) {
+    throw new Error("Search response did not match expected shape");
+  }
+
+  const thumbnails = searchResponse?.data
     .map(
-      (image) =>
-        image?.data?.thumbnail?.secureUrl || image?.data?.thumbnail?.file
+      (image) => image.data?.thumbnail?.secureUrl || image.data?.thumbnail?.file
     )
     .filter((thumbnail): thumbnail is string => !!thumbnail);
 
   return {
     total: searchResponse.total,
     thumbnails,
+    queryBreakdown: await queryBreakdown,
   };
 };
+
+const COLLECTIONS = /~(?:([^'"\s]+)|"([^"]+)"|'([^']+)')/g;
+const LABELS = /#(?:([^'"\s]+)|"([^"]+)"|'([^']+)')/g;
+async function breakdownQuery(
+  q: string | null
+): Promise<GridSearchQueryBreakdown | null> {
+  if (!q) return null;
+
+  const collections = await Promise.all(
+    [...q.matchAll(COLLECTIONS)].map(async (_) => {
+      const text = _[1] ?? _[2] ?? _[3];
+      const collectionResponse = await gridFetch(
+        `https://${collectionsDomain}/collections/${text}`
+      );
+
+      if (!isCollectionResponse(collectionResponse)) {
+        throw new Error("Fetching collection response failed as ");
+      }
+      return {
+        text: collectionResponse.data.fullPath.join("/"),
+        color: collectionResponse.data.cssColour ?? "#555",
+      };
+    })
+  );
+  const labels = [...q.matchAll(LABELS)].map((_) => ({
+    text: _[1] ?? _[2] ?? _[3],
+    color: "#00adee",
+  }));
+  const restOfSearch = q.replace(COLLECTIONS, "").replace(LABELS, "");
+
+  return {
+    collections,
+    labels,
+    restOfSearch,
+  };
+}

--- a/grid-bridge-lambda/src/index.ts
+++ b/grid-bridge-lambda/src/index.ts
@@ -14,6 +14,7 @@ const gutoolsDomain =
   STAGE === "PROD" ? "gutools.co.uk" : "test.dev-gutools.co.uk";
 const mediaApiDomain = `api.media.${gutoolsDomain}`;
 const collectionsDomain = `media-collections.${gutoolsDomain}`;
+const maxImagesInSummary = "4";
 
 export const handler = async (event: { arguments?: { apiUrl?: string } }) => {
   if (event.arguments?.apiUrl) {
@@ -42,7 +43,7 @@ const getSearchSummary = async (url: string): Promise<GridSearchSummary> => {
   ) {
     throw new Error("Invalid Grid search API URL");
   }
-  parsedUrl.searchParams.set("length", "4");
+  parsedUrl.searchParams.set("length", maxImagesInSummary);
 
   // Run api calls in parallel
   const search = gridFetch(parsedUrl.href);

--- a/grid-bridge-lambda/src/types.ts
+++ b/grid-bridge-lambda/src/types.ts
@@ -1,3 +1,29 @@
+export interface CollectionResponse {
+  data: Collection;
+}
+export const isCollectionResponse = (
+  possiblyCollectionResponse: any
+): possiblyCollectionResponse is CollectionResponse =>
+  "data" in possiblyCollectionResponse &&
+  isCollection(possiblyCollectionResponse.data);
+
+export interface Collection {
+  // incomplete type definition - represents this json write format https://github.com/guardian/grid/blob/e669dfc4b01aa4fdfa82893d535e4a86558319b3/collections/app/controllers/CollectionsController.scala#L181-L187
+  basename: string;
+  fullPath: string[];
+  cssColour?: string;
+}
+export const isCollection = (
+  possiblyCollection: any
+): possiblyCollection is Collection =>
+  typeof possiblyCollection.basename === "string" &&
+  Array.isArray(possiblyCollection.fullPath) &&
+  (possiblyCollection.fullPath as any[]).every(
+    (path) => typeof path === "string"
+  ) &&
+  (!("cssColour" in possiblyCollection) ||
+    typeof possiblyCollection.cssColour === "string");
+
 export interface SearchResponse {
   offset: number;
   length: number;
@@ -10,8 +36,8 @@ export const isSearchResponse = (
   typeof possiblyResponse.offset === "number" &&
   typeof possiblyResponse.length === "number" &&
   typeof possiblyResponse.total === "number" &&
-  Array.isArray(possiblyResponse.total) &&
-  (possiblyResponse.total as any[]).every(isImageResponse);
+  Array.isArray(possiblyResponse.data) &&
+  (possiblyResponse.data as any[]).every(isImageResponse);
 
 export interface ImageResponse {
   uri: string;
@@ -40,7 +66,7 @@ export const isThumbnail = (
   possiblyThumbnail: any
 ): possiblyThumbnail is Thumbnail =>
   typeof possiblyThumbnail.file === "string" &&
-  ("secureUrl" in possiblyThumbnail ||
+  (!("secureUrl" in possiblyThumbnail) ||
     typeof possiblyThumbnail.secureUrl === "string");
 
 export type GridId = string;

--- a/grid-bridge-lambda/src/types.ts
+++ b/grid-bridge-lambda/src/types.ts
@@ -1,0 +1,48 @@
+export interface SearchResponse {
+  offset: number;
+  length: number;
+  total: number;
+  data: ImageResponse[];
+}
+export const isSearchResponse = (
+  possiblyResponse: any
+): possiblyResponse is SearchResponse =>
+  typeof possiblyResponse.offset === "number" &&
+  typeof possiblyResponse.length === "number" &&
+  typeof possiblyResponse.total === "number" &&
+  Array.isArray(possiblyResponse.total) &&
+  (possiblyResponse.total as any[]).every(isImageResponse);
+
+export interface ImageResponse {
+  uri: string;
+  data: Image;
+}
+export const isImageResponse = (
+  possiblyResponse: any
+): possiblyResponse is ImageResponse =>
+  typeof possiblyResponse.uri === "string" && isImage(possiblyResponse.data);
+
+export interface Image {
+  // incomplete type definition - canonical definition at https://github.com/guardian/grid/blob/main/common-lib/src/main/scala/com/gu/mediaservice/model/Image.scala
+  id: GridId;
+  thumbnail?: Thumbnail;
+}
+export const isImage = (possiblyImage: any): possiblyImage is Image =>
+  isGridId(possiblyImage.id) &&
+  (!("thumbnail" in possiblyImage) || isThumbnail(possiblyImage.thumbnail));
+
+export interface Thumbnail {
+  // incomplete type definition - canonical definition at https://github.com/guardian/grid/blob/main/common-lib/src/main/scala/com/gu/mediaservice/model/Asset.scala
+  file: string;
+  secureUrl?: string;
+}
+export const isThumbnail = (
+  possiblyThumbnail: any
+): possiblyThumbnail is Thumbnail =>
+  typeof possiblyThumbnail.file === "string" &&
+  ("secureUrl" in possiblyThumbnail ||
+    typeof possiblyThumbnail.secureUrl === "string");
+
+export type GridId = string;
+export const isGridId = (possiblyId: string): possiblyId is GridId =>
+  !!possiblyId.match(/^[0-9a-f]{40}$/i);

--- a/grid-bridge-lambda/tsconfig.json
+++ b/grid-bridge-lambda/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bootstrapping-lambda",
     "cdk",
     "client",
+    "grid-bridge-lambda",
     "notifications-lambda",
     "users-refresher-lambda",
     "workflow-bridge-lambda"

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -16,6 +16,7 @@ deployments:
     dependencies:
       - pinboard-cloudformation
       - pinboard-workflow-bridge-lambda
+      - pinboard-grid-bridge-lambda
       - pinboard-users-refresher-lambda
       - pinboard-notifications-lambda
       - pinboard-auth-lambda
@@ -35,6 +36,16 @@ deployments:
       bucket: workflow-dist
       fileName: pinboard-workflow-bridge-lambda.zip
       functionNames: [pinboard-workflow-bridge-lambda-]
+
+  pinboard-grid-bridge-lambda:
+    dependencies:
+      - pinboard-cloudformation
+    type: aws-lambda
+    parameters:
+      prefixStack: false
+      bucket: workflow-dist
+      fileName: pinboard-grid-bridge-lambda.zip
+      functionNames: [pinboard-grid-bridge-lambda-]
 
   pinboard-users-refresher-lambda:
     dependencies:

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -48,9 +48,21 @@ type WorkflowStub {
   isNotFound: Boolean
 }
 
+type GridBadgeData {
+  text: String!
+  color: String!
+}
+
+type GridSearchQueryBreakdown {
+  collections: [GridBadgeData!]
+  labels: [GridBadgeData!]
+  restOfSearch: String
+}
+
 type GridSearchSummary {
   total: Int!
   thumbnails: [String!]!
+  queryBreakdown: GridSearchQueryBreakdown
 }
 
 type ItemConnection {

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -48,6 +48,11 @@ type WorkflowStub {
   isNotFound: Boolean
 }
 
+type GridSearchSummary {
+  total: Int!
+  thumbnails: [String!]!
+}
+
 type ItemConnection {
   items: [Item]
   nextToken: String
@@ -94,6 +99,8 @@ type Query {
   listPinboards(searchText: String): [WorkflowStub]
   getPinboardsByIds(ids: [String!]!): [WorkflowStub]
   getPinboardByComposerId(composerId: String!): WorkflowStub
+
+  getGridSearchSummary(apiUrl: String!): GridSearchSummary
 }
 
 type Subscription {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["esnext"],                        /* Specify library files to be included in the compilation. */
+    "lib": ["es2020"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Co-authored-by: @twrichards @Aracho1 

## What does this change?

Adds a lambda to bridge to grid APIs. Initital usage is to run searches for collections and labels.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Hard to exercise by itself as there are no UI changes in this PR. Deploy to CODE with #131, with guardian/grid#3713 on Grid TEST, and preview some searches (some examples are currently in the Pinboard named "NOW RENAMED", alternatively searches can be added from the local playground in #131).

## How can we measure success?

Pinboard is able to connect to Grid to fetch previews for searches.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
