### PR TITLE
Automatically add jest snapshots

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,11 @@ set -e
 
 yarn lint-staged
 
+if (git diff --name-only --cached | grep -e 'cdk' -e 'shared/graphql'); then 
+    yarn workspace cdk update-snapshot
+    git add cdk/test/__snapshots__/
+fi
+
 if (git diff --name-only --cached | grep 'yarn.lock'); then
     yarn yarn-deduplicate
     git add yarn.lock

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "tsc --noEmit & jest",
     "watch": "tsc --noEmit --watch & jest --watch",
-    "build": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts' > cloudformation.yaml"
+    "build": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts' > cloudformation.yaml",
+    "update-snapshot": "jest -u"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.147.0",


### PR DESCRIPTION
## What does this change?

Add a git hook that updates snapshots on commit when changes to cdk directory or graphql schema are detected. We want to do this because we found it frustrating to have a push fail in CI after forgetting to update the snapshot.

## How to test

Make a change to stack definition or graphql schema, and make a commit. The snapshot should be updated and included in the commit.

## Considerations

This change in this PR does mean that a developer will likely never see the snapshot 'test' fail, as the git hook will automatically run the update. We hope that this means the change to the snapshot will be inspected in the PR view and at review time and unexpected changes noted there, but if this does not happen we could change the hook to only run the test, hopefully encouraging the dev to inspect the changes at commit time instead.