### PR TITLE
Parse chips out of grid query

### DIFF
--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -173,6 +173,7 @@ type GridBadgeData {
 type GridSearchQueryBreakdown {
   collections: [GridBadgeData!]
   labels: [GridBadgeData!]
+  chips: [GridBadgeData!]
   restOfSearch: String
 }
 
@@ -376,7 +377,7 @@ input TableStringFilterInput {
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "ResponseMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -485,7 +486,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "item_table_datasource",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
       #set($input = $ctx.args.input)
       $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
@@ -518,7 +519,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "item_table_datasource",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -652,7 +653,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -690,7 +691,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -824,7 +825,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -869,7 +870,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -909,7 +910,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -949,7 +950,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -983,7 +984,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "listUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -1123,7 +1124,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "ResponseMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1144,7 +1145,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "ResponseMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1165,7 +1166,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 12419563e530a9332570743298e79259
+        "ResponseMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/grid-bridge-lambda/src/index.ts
+++ b/grid-bridge-lambda/src/index.ts
@@ -70,6 +70,7 @@ const getSearchSummary = async (url: string): Promise<GridSearchSummary> => {
 
 const COLLECTIONS = /~(?:([^'"\s]+)|"([^"]+)"|'([^']+)')/g;
 const LABELS = /#(?:([^'"\s]+)|"([^"]+)"|'([^']+)')/g;
+const CHIPS = /([^'"\s]+:(?:[^'"\s]+|"[^"]+"|'[^']+'))/g;
 async function breakdownQuery(
   q: string | null
 ): Promise<GridSearchQueryBreakdown | null> {
@@ -91,15 +92,25 @@ async function breakdownQuery(
       };
     })
   );
-  const labels = [...q.matchAll(LABELS)].map((_) => ({
+  const notCollections = q.replace(COLLECTIONS, "");
+
+  const labels = [...notCollections.matchAll(LABELS)].map((_) => ({
     text: _[1] ?? _[2] ?? _[3],
     color: "#00adee",
   }));
-  const restOfSearch = q.replace(COLLECTIONS, "").replace(LABELS, "");
+  const notLabels = notCollections.replace(LABELS, "");
+
+  const chips = [...notLabels.matchAll(CHIPS)].map((_) => ({
+    text: _[1] ?? _[2] ?? _[3],
+    color: "#333333",
+  }));
+  const notChips = notLabels.replace(CHIPS, "");
+  const restOfSearch = notChips.replace(/ {2,}/g, " ").trim();
 
   return {
     collections,
     labels,
+    chips,
     restOfSearch,
   };
 }

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -56,6 +56,7 @@ type GridBadgeData {
 type GridSearchQueryBreakdown {
   collections: [GridBadgeData!]
   labels: [GridBadgeData!]
+  chips: [GridBadgeData!]
   restOfSearch: String
 }
 


### PR DESCRIPTION
## What does this change?

Adds chips to the parsed parts of the grid query in grid-bridge-lambda

## How to test

Deploy to CODE, and either send searches through the appsync console or the lambda console, run locally by setting a url in `grid-bridge-lambda/run.ts`

## How can we measure success?

Can we always see the chips, have they been parsed correctly? Can you find/come up with a query that fails parsing?

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
