### PR TITLE
fix: Collections may not have a css colour

### DIFF
--- a/grid-bridge-lambda/src/types.ts
+++ b/grid-bridge-lambda/src/types.ts
@@ -23,7 +23,8 @@ export const isCollection = (
       typeof collection.basename === "string" &&
       Array.isArray(collection.fullPath) &&
       collection.fullPath.every((path) => typeof path === "string") &&
-      typeof collection.cssColour === "string"
+      (collection.cssColour === undefined ||
+        typeof collection.cssColour === "string")
     );
   }
   return false;


### PR DESCRIPTION
## What does this change?

Type predicate for collections api response required a cssColour, but that's an optional param

## How to test

try adding a collection that does not have a colour defined to a search payload (eg. `~g1`)

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
