### PR TITLE
FIX missing messages when re-opening a closed pinboard

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "test": "jest 2>&1"
   },
   "dependencies": {
-    "@apollo/client": "^3.5.5",
+    "@apollo/client": "^3.6.5",
     "@emotion/react": "^11.1.4",
     "@guardian/source-foundations": "^4.1.0",
     "@guardian/source-react-components": "^4.4.0",

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -110,6 +110,19 @@ export function mount({
       createSubscriptionHandshakeLink(apolloUrlInfo),
     ]),
     cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: "cache-and-network",
+        errorPolicy: "ignore",
+      },
+      query: {
+        fetchPolicy: "network-only",
+        errorPolicy: "all",
+      },
+      mutate: {
+        errorPolicy: "all",
+      },
+    },
   });
 
   const element = document.createElement("pinboard");

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -73,7 +73,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
 
   const [successfulSends, setSuccessfulSends] = useState<PendingItem[]>([]);
 
-  const initialItems = useQuery(gqlGetInitialItems(pinboardId));
+  const initialItemsQuery = useQuery(gqlGetInitialItems(pinboardId));
 
   const initialLastItemSeenByUsers = useQuery(
     gqlGetLastItemSeenByUsers(pinboardId)
@@ -131,8 +131,9 @@ export const Pinboard: React.FC<PinboardProps> = ({
   );
 
   useEffect(
-    () => setError(pinboardId, initialItems.error || itemSubscription.error),
-    [initialItems.error, itemSubscription.error]
+    () =>
+      setError(pinboardId, initialItemsQuery.error || itemSubscription.error),
+    [initialItemsQuery.error, itemSubscription.error]
   );
   const hasError = !!errors[pinboardId];
 
@@ -150,7 +151,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
 
   return !isSelected ? null : (
     <React.Fragment>
-      {initialItems.loading && "Loading..."}
+      {initialItemsQuery.loading && "Loading..."}
       {hasError && (
         <div
           css={css`
@@ -215,10 +216,10 @@ export const Pinboard: React.FC<PinboardProps> = ({
           flex-grow: 1;
         `}
       />
-      {activeTab === "chat" && initialItems.data && (
+      {activeTab === "chat" && initialItemsQuery.data && (
         <ScrollableItems
           showNotification={showNotification}
-          initialItems={initialItems.data.listItems.items}
+          initialItems={initialItemsQuery.data.listItems.items}
           successfulSends={successfulSends}
           subscriptionItems={subscriptionItems}
           setUnreadFlag={setUnreadFlag(pinboardId)}
@@ -229,9 +230,9 @@ export const Pinboard: React.FC<PinboardProps> = ({
           lastItemSeenByUserLookup={lastItemSeenByUserLookup}
         />
       )}
-      {activeTab === "asset" && initialItems.data && (
+      {activeTab === "asset" && initialItemsQuery.data && (
         <AssetView
-          initialItems={initialItems.data.listItems.items}
+          initialItems={initialItemsQuery.data.listItems.items}
           successfulSends={successfulSends}
           subscriptionItems={subscriptionItems}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,23 +9,23 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@apollo/client@^3.5.5":
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.5.tgz#ce331403ee5f099e595430890f9b510c8435c932"
-  integrity sha512-EiQstc8VjeqosS2h21bwY9fhL3MCRRmACtRrRh2KYpp9vkDyx5pUfMnN3swgiBVYw1twdXg9jHmyZa1gZlvlog==
+"@apollo/client@^3.6.5":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.5.tgz#6a7baaf05852187b0eac1c6064e721d47326d70c"
+  integrity sha512-xGAZzv1f5abyH45MSU5eOLyGQuP4Ps0OhP36pSCtt6pCICI3n4yDkdftFCPvqDVqVTuciX1kkyeJPfGodz5kwg==
   dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
+    "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.6.0"
     "@wry/equality" "^0.5.0"
     "@wry/trie" "^0.3.0"
-    graphql-tag "^2.12.3"
+    graphql-tag "^2.12.6"
     hoist-non-react-statics "^3.3.2"
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
+    ts-invariant "^0.10.3"
     tslib "^2.3.0"
-    zen-observable-ts "^1.2.0"
+    zen-observable-ts "^1.2.5"
 
 "@ardatan/aggregate-error@0.0.6":
   version "0.0.6"
@@ -2408,10 +2408,10 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-typed-document-node/core@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@guardian/node-riffraff-artifact@0.3.2":
   version "0.3.2"
@@ -6622,7 +6622,7 @@ graphql-request@^3.3.0:
     extract-files "^9.0.0"
     form-data "^3.0.0"
 
-graphql-tag@^2.11.0, graphql-tag@^2.12.3:
+graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -11083,10 +11083,10 @@ ts-easing@^0.2.0:
   resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
   integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
-ts-invariant@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
-  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -11983,10 +11983,10 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zen-observable-ts@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
-  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
   dependencies:
     zen-observable "0.8.15"
 


### PR DESCRIPTION
We've long noticed an odd (albeit rarely seen) bug when some recently sent/received messages don't appear after re-opening a pinboard (without having refreshed the page). A hunch led me to think it might be cache related (Apollo GraphQL library caches request by default).

So this PR forces a network request for all queries (by specifying `fetchPolicy` in the `defaultOptions` of the ApolloClient as per https://www.apollographql.com/docs/react/api/core/ApolloClient/#example-defaultoptions-object).

We also upgrade `@apollo/client` to latest for good measure (but also because there's various GH issues relating to bugs in how `defaultOptions` are applied which are fixed in more recent versions).

## How to test
Easiest in CODE. Open pinbaord when at the root/dashboard of CODE composer (or TEST grid), open a pinboard, send some messages, navigate back to the pinboard select screen, close the pinboard (the X beside the pinboard in the My Pinboards) list, then search for it and re-open and all the messages you sent should be there (they would have been missing before this fix).