### PR TITLE
FIX tiny images in asset view

### DIFF
--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -60,20 +60,10 @@ export const AssetView: React.FC<AssetView> = ({
       `}
     >
       {payloadsMap.map((payloadAndType) => (
-        <div
+        <PayloadDisplay
           key={payloadAndType.payload.embeddableUrl}
-          css={css`
-            margin: ${space[1]}px;
-            border: 1px solid ${neutral[86]};
-            border-radius: ${space[1]}px;
-            max-width: fit-content;
-            &:hover {
-              background-color: ${neutral[86]};
-            }
-          `}
-        >
-          <PayloadDisplay payloadAndType={payloadAndType} />
-        </div>
+          payloadAndType={payloadAndType}
+        />
       ))}
     </div>
   );

--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { neutral, palette, space } from "@guardian/source-foundations";
+import { palette, space } from "@guardian/source-foundations";
 import React from "react";
 import { scrollbarsCss } from "./styling";
 import type { Item } from "../../shared/graphql/graphql";

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -112,6 +112,10 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 }) => {
   const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
 
+  useEffect(() => {
+    payloadToBeSent && setActiveTab(ChatTab);
+  }, [payloadToBeSent]);
+
   const [getPreselectedPinboard, preselectedPinboardQuery] = useLazyQuery(
     gqlGetPinboardByComposerId
   );

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 import { css } from "@emotion/react";
 import { PayloadDisplay } from "./payloadDisplay";
 import { PendingItem } from "./types/PendingItem";
-import { neutral, palette, space } from "@guardian/source-foundations";
+import { palette, space } from "@guardian/source-foundations";
 import { userToMentionHandle } from "./util";
 import { SeenBy } from "./seenBy";
 import { AvatarRoundel } from "./avatarRoundel";

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   bottom,
   boxShadow,
@@ -14,6 +14,7 @@ import { Navigation } from "./navigation";
 import { useGlobalStateContext } from "./globalState";
 import { getTooltipText } from "./util";
 import { dropTargetCss, IsDropTargetProps } from "./drop";
+import { ChatTab } from "./types/Tab";
 
 export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -40,6 +41,10 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     }
     return "Select a pinboard";
   })();
+
+  useEffect(() => {
+    setActiveTab(ChatTab);
+  }, [selectedPinboardId]);
 
   return (
     <div


### PR DESCRIPTION
...by removing redundant wrapper around `PayloadDisplay` in `AssetView` (missed in https://github.com/guardian/pinboard/pull/137) 

### ALSO 
- ensure ChatTab is selected when there is a 'payload to be sent' added (since it cannot be sent from the Asset tab)
- ensure ChatTab is selected when switching between pinboards, so that nobody accidentally misses messages because they're stuck in the AssetTab
