### PR TITLE
positionable Floaty/Panel

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "date-fns": "^2.19.0",
     "graphql": "^15.4.0",
     "preact": "^10.5.13",
+    "react-draggable": "^4.4.5",
     "react-shadow": "^19.0.2"
   },
   "devDependencies": {

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -46,13 +46,13 @@ export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     setIsExpanded,
     hasError,
     hasUnread,
+    isRepositioning,
+    setIsRepositioning,
     explicitPositionTranslation,
     setExplicitPositionTranslation,
     boundedPositionTranslation,
     updateBoundedPositionTranslation,
   } = useGlobalStateContext();
-
-  const [isDragging, setIsDragging] = useState<boolean>(false);
 
   const badge = (() => {
     if (hasError) {
@@ -86,19 +86,19 @@ export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
       position={boundedPositionTranslation}
       onDrag={(event, position) => {
         window.getSelection()?.removeAllRanges(); // clear text selection that sometimes happens when dragging
-        if (isDragging) {
+        if (isRepositioning) {
           setExplicitPositionTranslation(position);
           updateBoundedPositionTranslation(position);
         } else if (
           Math.abs(explicitPositionTranslation.x - position.x) > 5 ||
           Math.abs(explicitPositionTranslation.y - position.y) > 5
         ) {
-          setIsDragging(true);
+          setIsRepositioning(true);
         }
       }}
       onStop={() => {
-        if (isDragging) {
-          setTimeout(() => setIsDragging(false), 1);
+        if (isRepositioning) {
+          setTimeout(() => setIsRepositioning(false), 1);
         } else {
           setIsExpanded(!isExpanded);
           sendTelemetryEvent?.(
@@ -118,7 +118,7 @@ export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
           width: ${floatySize}px;
           height: ${floatySize}px;
           border-radius: ${floatySize / 2}px;
-          cursor: ${isDragging ? "move" : "pointer"};
+          cursor: ${isRepositioning ? "move" : "pointer"};
           box-shadow: ${boxShadow};
           background-color: ${pinboard[500]};
           &:hover {

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -85,18 +85,19 @@ export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     <Draggable
       position={boundedPositionTranslation}
       onDrag={(event, position) => {
-        if (isDragging) return;
-        if (
+        window.getSelection()?.removeAllRanges(); // clear text selection that sometimes happens when dragging
+        if (isDragging) {
+          setExplicitPositionTranslation(position);
+          updateBoundedPositionTranslation(position);
+        } else if (
           Math.abs(explicitPositionTranslation.x - position.x) > 5 ||
           Math.abs(explicitPositionTranslation.y - position.y) > 5
         ) {
           setIsDragging(true);
         }
       }}
-      onStop={(event, position) => {
+      onStop={() => {
         if (isDragging) {
-          setExplicitPositionTranslation(position);
-          updateBoundedPositionTranslation(position);
           setTimeout(() => setIsDragging(false), 1);
         } else {
           setIsExpanded(!isExpanded);

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { css } from "@emotion/react";
 import { pinMetal, pinboard, composer } from "../colours";
 import PinIcon from "../icons/pin-icon.svg";

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -24,7 +24,6 @@ import type { PreselectedPinboard } from "../../shared/graphql/extraTypes";
 import { ChatTab, Tab } from "./types/Tab";
 import { ControlPosition } from "react-draggable";
 import { bottom, top, floatySize, right } from "./styling";
-import { useThrottle } from "./util";
 
 const LOCAL_STORAGE_KEY_EXPLICIT_POSITION = "pinboard-explicit-position";
 

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -24,7 +24,7 @@ import type { PreselectedPinboard } from "../../shared/graphql/extraTypes";
 import { ChatTab, Tab } from "./types/Tab";
 import { ControlPosition } from "react-draggable";
 import { bottom, top, floatySize, right } from "./styling";
-import { useDebounce } from "./util";
+import { useThrottle } from "./util";
 
 const LOCAL_STORAGE_KEY_EXPLICIT_POSITION = "pinboard-explicit-position";
 
@@ -396,10 +396,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     updateBoundedPositionTranslation(explicitPositionTranslation);
   }, [lastResized]);
 
-  const resizeCompleteHandler = useDebounce(
-    () => setLastResized(Date.now()),
-    250
-  );
+  const resizeCompleteHandler = useThrottle(() => setLastResized(Date.now()));
 
   useEffect(() => {
     const savedExplicitPositionTranslation = JSON.parse(

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -23,7 +23,7 @@ import { isPinboardData } from "../../shared/graphql/extraTypes";
 import type { PreselectedPinboard } from "../../shared/graphql/extraTypes";
 import { ChatTab, Tab } from "./types/Tab";
 import { ControlPosition } from "react-draggable";
-import { bottom, floatySize, right } from "./styling";
+import { bottom, top, floatySize, right } from "./styling";
 import { useDebounce } from "./util";
 
 const LOCAL_STORAGE_KEY_EXPLICIT_POSITION = "pinboard-explicit-position";
@@ -351,7 +351,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     const viewportHeight = document.documentElement.clientHeight;
 
     const isTooFarLeft = viewportWidth + positionTranslation.x < floatySize;
-    const isTooHigh = viewportHeight + positionTranslation.y < floatySize;
+    const isTooHigh = viewportHeight + positionTranslation.y < floatySize + top;
     return {
       x: isTooFarLeft
         ? 10 + floatySize - viewportWidth
@@ -359,7 +359,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
         ? -10
         : positionTranslation.x,
       y: isTooHigh
-        ? 10 + floatySize - viewportHeight
+        ? top + floatySize - viewportHeight
         : isTooLow
         ? -10
         : positionTranslation.y,

--- a/client/src/navigation/index.tsx
+++ b/client/src/navigation/index.tsx
@@ -15,8 +15,14 @@ interface NavigationProps {
   selectedPinboardId: string | null | undefined;
   clearSelectedPinboard: () => void;
   headingTooltipText: string | undefined;
+  isTopHalf: boolean;
+  isLeftHalf: boolean;
 }
-export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
+export const Navigation = ({
+  isTopHalf,
+  isLeftHalf,
+  ...props
+}: PropsWithChildren<NavigationProps>) => {
   const {
     setIsExpanded,
     hasUnreadOnOtherPinboard,
@@ -37,8 +43,12 @@ export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
     <div
       css={css`
         background-color: ${pinboard[500]};
-        border-top-left-radius: 4px;
-        border-top-right-radius: 4px;
+        border-top-${isLeftHalf ? "right" : "left"}-radius: 4px;
+        ${
+          isTopHalf
+            ? ""
+            : `border-top-${isLeftHalf ? "left" : "right"}-radius: 4px;`
+        }
         box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 4px;
         clip-path: inset(0 0 -40px 0);
       `}

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import React, { useEffect, useRef } from "react";
-import { bottom, boxShadow, floatySize, panelCornerSize } from "./styling";
+import { bottom, boxShadow, floatySize, panelCornerSize, top } from "./styling";
 import { Pinboard } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
 import { neutral, space } from "@guardian/source-foundations";
@@ -61,7 +61,7 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
             ? `calc(100vh + ${
                 space[2] + panelCornerSize + boundedPositionTranslation.y
               }px)`
-            : "65px"
+            : `${top}px`
         };
         bottom: ${
           isTopHalf

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -1,12 +1,6 @@
 import { css } from "@emotion/react";
 import React, { useEffect, useRef } from "react";
-import {
-  bottom,
-  boxShadow,
-  floatySize,
-  panelCornerSize,
-  right,
-} from "./styling";
+import { bottom, boxShadow, floatySize, panelCornerSize } from "./styling";
 import { Pinboard } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
 import { neutral, space } from "@guardian/source-foundations";
@@ -15,6 +9,7 @@ import { useGlobalStateContext } from "./globalState";
 import { getTooltipText } from "./util";
 import { dropTargetCss, IsDropTargetProps } from "./drop";
 import { ChatTab } from "./types/Tab";
+import { pinboard } from "../colours";
 
 export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -26,6 +21,7 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     clearSelectedPinboard,
     activeTab,
     setActiveTab,
+    boundedPositionTranslation,
   } = useGlobalStateContext();
 
   const selectedPinboard = activePinboards.find(
@@ -46,6 +42,11 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     setActiveTab(ChatTab);
   }, [selectedPinboardId]);
 
+  const isLeftHalf =
+    Math.abs(boundedPositionTranslation.x) > window.innerWidth / 2;
+  const isTopHalf =
+    Math.abs(boundedPositionTranslation.y) > window.innerHeight / 2;
+
   return (
     <div
       css={css`
@@ -54,35 +55,51 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
         background: ${neutral[93]};
         box-shadow: ${boxShadow};
         width: 260px;
-        height: 68vh;
-        min-height: 380px;
-        max-height: min(
-          800px,
-          calc(98vh - ${bottom + floatySize + space[4] + panelCornerSize}px)
-        );
-        bottom: ${bottom + floatySize + space[2] + panelCornerSize}px;
-        right: ${right + floatySize / 2}px;
+        transform: translateX(${isLeftHalf ? "100%" : 0});
+        top: ${
+          isTopHalf
+            ? `calc(100vh + ${
+                space[2] + panelCornerSize + boundedPositionTranslation.y
+              }px)`
+            : "65px"
+        };
+        bottom: ${
+          isTopHalf
+            ? bottom
+            : Math.abs(boundedPositionTranslation.y) +
+              floatySize +
+              space[2] +
+              panelCornerSize
+        }px;
+        right: ${Math.abs(boundedPositionTranslation.x) + floatySize / 2}px;
         display: ${isExpanded ? "flex" : "none"};
         flex-direction: column;
         font-family: sans-serif;
-        border-top-left-radius: 4px;
-        border-top-right-radius: 4px;
-
-        &::after {
-          content: "";
-          position: fixed;
-          background: ${neutral[93]};
-          width: ${panelCornerSize}px;
-          height: ${panelCornerSize}px;
-          bottom: ${bottom + floatySize + space[2]}px;
-          right: ${right + floatySize / 2}px;
-          border-bottom-left-radius: ${panelCornerSize}px;
-          box-shadow: ${boxShadow};
-          clip: rect(0, 50px, 50px, -25px); // clip off the top of the shadow
-        }
+        border-radius: 4px;
+        border-${isTopHalf ? "top" : "bottom"}-${
+        isLeftHalf ? "left" : "right"
+      }-radius: 0;
       `}
       ref={panelRef}
     >
+      <div
+        css={css`
+          position: absolute;
+          background: ${isTopHalf ? pinboard["500"] : neutral[93]};
+          width: ${panelCornerSize}px;
+          height: ${panelCornerSize}px;
+          ${isTopHalf ? "top" : "bottom"}: -${panelCornerSize - 1}px;
+          ${isLeftHalf ? "left" : "right"}: 0;
+          right: 0;
+          border-${isTopHalf ? "top" : "bottom"}-${
+          isLeftHalf ? "right" : "left"
+        }-radius: ${panelCornerSize}px;
+          box-shadow: ${boxShadow};
+          clip: rect(${
+            isTopHalf ? -5 : 0
+          }px, 50px, 50px, -25px); // clip off the top of the shadow FIXME make relative
+      `}
+      />
       {isDropTarget && <div css={{ ...dropTargetCss }} />}
       <Navigation
         activeTab={activeTab}
@@ -92,6 +109,8 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
         headingTooltipText={
           selectedPinboard && getTooltipText(selectedPinboard)
         }
+        isTopHalf={isTopHalf}
+        isLeftHalf={isLeftHalf}
       >
         <span
           css={{

--- a/client/src/styling.ts
+++ b/client/src/styling.ts
@@ -1,7 +1,7 @@
 import { css, CSSObject } from "@emotion/react";
 import { space } from "@guardian/source-foundations";
 
-export const bottom = 108;
+export const bottom = 108; // to account for Teleporter
 export const right = 15;
 export const floatySize = 40;
 export const boxShadow =

--- a/client/src/styling.ts
+++ b/client/src/styling.ts
@@ -1,6 +1,7 @@
 import { css, CSSObject } from "@emotion/react";
 import { space } from "@guardian/source-foundations";
 
+export const top = 95; // to account for important toolbars/buttons in grid and composer
 export const bottom = 108; // to account for Teleporter
 export const right = 15;
 export const floatySize = 40;

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -53,3 +53,16 @@ export const formatDateTime = (
     return format(timestamp, "d MMM yyyy HH:mm");
   }
 };
+
+export const useDebounce = (func: () => void, milliseconds: number) => {
+  const time = milliseconds || 250;
+  let timer: number;
+
+  return (event: Event) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    timer = setTimeout(func, time, event);
+  };
+};

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -54,15 +54,28 @@ export const formatDateTime = (
   }
 };
 
-export const useDebounce = (func: () => void, milliseconds: number) => {
-  const time = milliseconds || 250;
-  let timer: number;
+export const useThrottle = <E>(
+  callback: (event: E) => void,
+  milliseconds?: number
+) => {
+  //initialize throttlePause variable outside throttle function
+  let throttlePause: boolean;
 
-  return (event: Event) => {
-    if (timer) {
-      clearTimeout(timer);
-    }
+  const time = milliseconds || 33; // 33 default is roughly 30 times a second (approx frame rate of human eye)
 
-    timer = setTimeout(func, time, event);
+  return (event: E) => {
+    //don't run the function if throttlePause is true
+    if (throttlePause) return;
+
+    //set throttlePause to true after the if condition. This allows the function to be run once
+    throttlePause = true;
+
+    //setTimeout runs the callback within the specified time
+    setTimeout(() => {
+      callback(event);
+
+      //throttlePause is set to false once the function has been called, allowing the throttle function to loop
+      throttlePause = false;
+    }, time);
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9590,7 +9590,7 @@ react-draggable@^4.4.5:
     clsx "^1.1.1"
     prop-types "^15.8.1"
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4671,6 +4671,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9471,14 +9476,14 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+prop-types@^15.7.2, prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
   dependencies:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
-    react-is "^16.8.1"
+    react-is "^16.13.1"
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -9577,7 +9582,15 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-draggable@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.5.tgz#9e37fe7ce1a4cf843030f521a0a4cc41886d7e7c"
+  integrity sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==
+  dependencies:
+    clsx "^1.1.1"
+    prop-types "^15.8.1"
+
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
https://trello.com/c/1uT2Mdth/194-pinboard-positionable-floaty-panel

Following feedback from users (along with our own observations/suspicions) its necessary to be able to move the pinboard floaty/panel sometimes (e.g. to see info in the grid in the right sidebar).

## Requirements
- persists between reloads (per domain, so it can be different for composer vs grid for example)
- panel sits appropriately w.r.t. the floaty, depending on which quadrant of the screen the floaty is placed
- cannot be dragged off the screen (including when the screen is resized, it can't move off the edge) 

![positionable_final](https://user-images.githubusercontent.com/19289579/184318381-e2daf91f-06f1-401d-89d4-4532035965bf.gif)
