### PR TITLE
FIX ensure notifications are not sent back to the author of the message

### DIFF
--- a/notifications-lambda/src/index.ts
+++ b/notifications-lambda/src/index.ts
@@ -75,7 +75,8 @@ export const handler = async (event: DynamoDBStreamEvent) => {
               // TODO: Include more scenarios that trigger desktop notification
               (item) =>
                 isUserMentioned(item, user) ||
-                doesUserManuallyHavePinboardOpen(item, user)
+                (item.userEmail !== user.email && // ensure we don't notify the person who sent the message
+                  doesUserManuallyHavePinboardOpen(item, user))
             )
             .map((item) =>
               webPush


### PR DESCRIPTION
…unless they 'mention' themselves.

Surprised we made this oversight, but I noticed I was getting notifications for each message I send - this PR fixes that