### PR TITLE
replace DynamoDB Streams for the `notifications-lambda` with SQS and a AppSync pipeline resolver

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -28,6 +28,7 @@
     "@aws-cdk/aws-lambda-event-sources": "1.147.0",
     "@aws-cdk/aws-s3": "1.147.0",
     "@aws-cdk/aws-ssm": "1.147.0",
+    "@aws-cdk/aws-sqs": "1.147.0",
     "@aws-cdk/core": "1.147.0"
   }
 }

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -107,6 +107,42 @@ Object {
       },
       "Type": "AWS::AppSync::GraphQLApi",
     },
+    "pinboardappsyncapiMutationcreateItemResolverFA9560B7": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "FieldName": "createItem",
+        "Kind": "PIPELINE",
+        "PipelineConfig": Object {
+          "Functions": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "pinboardinsertitempipelinefunction3F6F60CF",
+                "FunctionId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "pinboardqueuenotificationpipelinefunction6293EB5F",
+                "FunctionId",
+              ],
+            },
+          ],
+        },
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
+{}",
+        "ResponseMappingTemplate": "$util.toJson($context.result)",
+        "TypeName": "Mutation",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
     "pinboardappsyncapiSchema868D9F5B": Object {
       "Properties": Object {
         "ApiId": Object {
@@ -471,39 +507,6 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::AppSync::DataSource",
     },
-    "pinboardappsyncapiitemtabledatasourceMutationcreateItemResolver7AEC9201": Object {
-      "DependsOn": Array [
-        "pinboardappsyncapiitemtabledatasourceFD08E0E9",
-        "pinboardappsyncapiSchema868D9F5B",
-      ],
-      "Properties": Object {
-        "ApiId": Object {
-          "Fn::GetAtt": Array [
-            "pinboardappsyncapi9D519400",
-            "ApiId",
-          ],
-        },
-        "DataSourceName": "item_table_datasource",
-        "FieldName": "createItem",
-        "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
-
-      #set($input = $ctx.args.input)
-      $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
-$util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
-      {
-        \\"version\\": \\"2017-02-28\\",
-        \\"operation\\": \\"PutItem\\",
-        \\"key\\" : {
-      \\"id\\" : $util.dynamodb.toDynamoDBJson($util.autoId())
-    },
-        \\"attributeValues\\": $util.dynamodb.toMapValuesJson($input)
-      }",
-        "ResponseMappingTemplate": "$util.toJson($ctx.result)",
-        "TypeName": "Mutation",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
     "pinboardappsyncapiitemtabledatasourceQuerylistItemsResolver15E3DD35": Object {
       "DependsOn": Array [
         "pinboardappsyncapiitemtabledatasourceFD08E0E9",
@@ -778,6 +781,94 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "Roles": Array [
           Object {
             "Ref": "pinboardappsyncapilastitemseenbyusertabledatasourceServiceRole1E70FCA2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pinboardappsyncapinotificationslambdadsFB281B61": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "LambdaConfig": Object {
+          "LambdaFunctionArn": Object {
+            "Fn::GetAtt": Array [
+              "pinboardnotificationslambdaC35CECF7",
+              "Arn",
+            ],
+          },
+        },
+        "Name": "notifications_lambda_ds",
+        "ServiceRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapinotificationslambdadsServiceRoleC527BA2E",
+            "Arn",
+          ],
+        },
+        "Type": "AWS_LAMBDA",
+      },
+      "Type": "AWS::AppSync::DataSource",
+    },
+    "pinboardappsyncapinotificationslambdadsServiceRoleC527BA2E": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "appsync.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pinboardappsyncapinotificationslambdadsServiceRoleDefaultPolicyC86ED932": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "pinboardnotificationslambdaC35CECF7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pinboardappsyncapinotificationslambdadsServiceRoleDefaultPolicyC86ED932",
+        "Roles": Array [
+          Object {
+            "Ref": "pinboardappsyncapinotificationslambdadsServiceRoleC527BA2E",
           },
         ],
       },
@@ -2254,6 +2345,38 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "pinboardinsertitempipelinefunction3F6F60CF": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapiitemtabledatasourceFD08E0E9",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "item_table_datasource",
+        "FunctionVersion": "2018-05-29",
+        "Name": "insert_item",
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
+
+      #set($input = $ctx.args.input)
+      $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
+$util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
+      {
+        \\"version\\": \\"2017-02-28\\",
+        \\"operation\\": \\"PutItem\\",
+        \\"key\\" : {
+      \\"id\\" : $util.dynamodb.toDynamoDBJson($util.autoId())
+    },
+        \\"attributeValues\\": $util.dynamodb.toMapValuesJson($input)
+      }",
+        "ResponseMappingTemplate": "$util.toJson($ctx.result)",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
+    },
     "pinboarditemtable83382753": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
@@ -2382,6 +2505,9 @@ $util.toJson($ctx.result)",
         "Environment": Object {
           "Variables": Object {
             "APP": "pinboard",
+            "NOTIFICATION_QUEUE_URL": Object {
+              "Ref": "pinboardnotificationslambdasqsC013918E",
+            },
             "STACK": Object {
               "Ref": "Stack",
             },
@@ -2434,23 +2560,6 @@ $util.toJson($ctx.result)",
         "Timeout": 30,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "pinboardnotificationslambdaDynamoDBEventSourcePinBoardStackpinboarditemtableB307C42935A18399": Object {
-      "Properties": Object {
-        "BatchSize": 100,
-        "EventSourceArn": Object {
-          "Fn::GetAtt": Array [
-            "pinboarditemtable83382753",
-            "StreamArn",
-          ],
-        },
-        "FunctionName": Object {
-          "Ref": "pinboardnotificationslambdaC35CECF7",
-        },
-        "MaximumBatchingWindowInSeconds": 10,
-        "StartingPosition": "LATEST",
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
     },
     "pinboardnotificationslambdaServiceRole2F6EBFE9": Object {
       "Properties": Object {
@@ -2526,6 +2635,16 @@ $util.toJson($ctx.result)",
               },
             },
             Object {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "pinboardnotificationslambdasqsC013918E",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
               "Action": Array [
                 "dynamodb:BatchGetItem",
                 "dynamodb:GetRecords",
@@ -2550,21 +2669,18 @@ $util.toJson($ctx.result)",
               ],
             },
             Object {
-              "Action": "dynamodb:ListStreams",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
               "Action": Array [
-                "dynamodb:DescribeStream",
-                "dynamodb:GetRecords",
-                "dynamodb:GetShardIterator",
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
               ],
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "pinboarditemtable83382753",
-                  "StreamArn",
+                  "pinboardnotificationslambdasqsC013918E",
+                  "Arn",
                 ],
               },
             },
@@ -2579,6 +2695,69 @@ $util.toJson($ctx.result)",
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "pinboardnotificationslambdaSqsEventSourcePinBoardStackpinboardnotificationslambdasqs6993908FF9F3EA04": Object {
+      "Properties": Object {
+        "EventSourceArn": Object {
+          "Fn::GetAtt": Array [
+            "pinboardnotificationslambdasqsC013918E",
+            "Arn",
+          ],
+        },
+        "FunctionName": Object {
+          "Ref": "pinboardnotificationslambdaC35CECF7",
+        },
+        "FunctionResponseTypes": Array [
+          "ReportBatchItemFailures",
+        ],
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "pinboardnotificationslambdasqsC013918E": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "pinboardqueuenotificationpipelinefunction6293EB5F": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapinotificationslambdadsFB281B61",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "notifications_lambda_ds",
+        "FunctionVersion": "2018-05-29",
+        "Name": "queue_notification",
+        "RequestMappingTemplate": "## schema checksum : 069f29169cf579ccf5c31b1d41c78246
+{\\"version\\": \\"2017-02-28\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $util.toJson($ctx.prev.result)}",
+        "ResponseMappingTemplate": "$util.toJson($ctx.result)",
+      },
+      "Type": "AWS::AppSync::FunctionConfiguration",
     },
     "pinboardusersrefresherlambda2D488032": Object {
       "DependsOn": Array [

--- a/notifications-lambda/run.ts
+++ b/notifications-lambda/run.ts
@@ -1,20 +1,22 @@
 import { handler } from "./src";
+import { Item } from "../shared/graphql/graphql";
+import { SQSRecord } from "aws-lambda";
+
+const item: Item = {
+  pinboardId: "63923",
+  payload: null,
+  mentions: ["tom.richards@guardian.co.uk"],
+  userEmail: "tom.richards@guardian.co.uk",
+  id: "535b86e2-4f01-4f60-a2d0-a5e4f5a7d312",
+  message: "testing one two three",
+  type: "message-only",
+  timestamp: "1630517452",
+};
 
 handler({
   Records: [
     {
-      dynamodb: {
-        NewImage: {
-          pinboardId: { S: "63923" },
-          payload: { NULL: true },
-          mentions: { L: [{ S: "tom.richards@guardian.co.uk" }] },
-          userEmail: { S: "tom.richards@guardian.co.uk" },
-          id: { S: "535b86e2-4f01-4f60-a2d0-a5e4f5a7d312" },
-          message: { S: "testing one two three" },
-          type: { S: "message-only" },
-          timestamp: { N: "1630517452" },
-        },
-      },
-    },
+      body: JSON.stringify(item),
+    } as SQSRecord, // casting here to avoid populating loads of fields of SQSRecord which are not used by the handler
   ],
 });

--- a/shared/environmentVariables.ts
+++ b/shared/environmentVariables.ts
@@ -3,6 +3,7 @@ export const ENVIRONMENT_VARIABLE_KEYS = {
   workflowDnsName: "WORKFLOW_DATASTORE_LOAD_BALANCER_DNS_NAME",
   graphqlEndpoint: "GRAPHQL_ENDPOINT",
   sentryDSN: "SENTRY_DSN",
+  notificationQueueURL: "NOTIFICATION_QUEUE_URL",
 };
 
 export const getEnvironmentVariableOrThrow = (

--- a/shared/graphql/extraTypes.ts
+++ b/shared/graphql/extraTypes.ts
@@ -1,4 +1,4 @@
-import type { WorkflowStub } from "./graphql";
+import type { Item, WorkflowStub } from "./graphql";
 
 export type PinboardData = WorkflowStub;
 
@@ -14,3 +14,6 @@ export const isPinboardData = (
   !!maybePinboardData &&
   maybePinboardData !== "loading" &&
   maybePinboardData !== "notTrackedInWorkflow";
+
+export const isItem = (maybeItem: unknown): maybeItem is Item =>
+  !!maybeItem && typeof maybeItem === "object" && "pinboardId" in maybeItem;


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 

https://trello.com/c/VzkeAK2f/554-migrate-pinboard-to-relational-database

In the database ADR (specifically https://github.com/guardian/pinboard/blob/ce8309a7eb088e7ae4814f9777dab0fa620387ac/ADRs/database.md?plain=1#L39) we had stated that we could replace 'DynamoDB Streams' with an `invoke_lambda` (from within the Aurora DB engine) when we move from Dynamo to RDS. However upon further investigation/experimentation, due to the fact we must use Aurora ServerlessV1 (because it's the only thing which supports the `data-api`, which AppSync relies upon) this doesn't support attaching IAM roles and so we cannot permission the RDS cluster to invoke the lambda - putting an end to that approach. As the changes to the database ADR in this PR explain, that leaves us with two choices...

- ~add a lambda and RDS proxy between AppSync and RDS (as explained in https://aws.amazon.com/blogs/mobile/appsync-graphql-sql-rds-proxy)~ - this seems like too much infrastructure complexity (at this point)
- convert the `createItem` AppSync resolver to an AppSync 'pipeline' resolver, where the first function does the DB insert as before, then the second function invokes the lambda (and we leave the lambda to look-up what it needs to from the DB, a shame but worth it) - this is the solution we went for in this PR and can be done before any re-platforming from DynamoDB to RDS (to make that task simpler later on).

## What does this change?

- convert the existing `createItem` resolver (defined in CDK) into a 'resolver function' 
- add `notifications-lambda` as an AppSync 'data source' and add a 'resolver function' to invoke it, with the output of the insert (which includes the inserted item's generated ID)
- wire the above together into a 'pipeline' resolver, which is assigned to the `createItem` Mutation
- update the `notifications-lambda` to receive the payload sent from the new 'resolver function' above (rather than the 'DynamoDB Streams' payload) and then queue it on an SQS queue, so that the pipeline resolver can return quickly (and the user/client isn't waiting on all the notifications being sent before they know their message has been inserted)...
- ... add an SQS queue to receive items which need notifications sending, which is wired up to the `notifications-lambda`...
- ... have the `notifications-lambda` also be able to be invoked with an `SQSEvent` (containing the item that it has just queued) to then do roughly what it used to (i.e. lookup which users need to receive a push notification for that item and send out all the push notifications)

## How to test
With this branch deployed to CODE (you'll need to check the pipeline resolver gets attached OK, as AWS' cloudformation of AppSync things is buggy, see https://github.com/aws/aws-appsync-community/issues/146#issuecomment-820290287 for example)...

- ensure you've subscribed to desktop notifications in pinboard (you'll see a button for it at the top of the pinboard panel if you haven't already subscribed)
- send a message mentioning yourself (mention people by typing `@` and selecting yourself)
**- ... you should still receive a desktop notification**

## How can we measure success?
This is kind of a no-op (functionality wise) but removes this complexity from the process of re-platforming from DynamoDB to RDS (where otherwise we would've had to do the `lambda_invoke` thing along the way.

## Have we considered potential risks?
There will be a performance hit when sending a message (more so when the `notifications-lambda` is cold), but from our testing this is tolerable.
