### PR TITLE
FIX extremely frequent `getPinboardsByIds` GraphQL calls

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -76,20 +76,23 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
     );
 
   const refreshPreselectedPinboard = () => {
-    if (preSelectedComposerIdFromQueryParam) {
+    if (
+      preSelectedComposerIdFromQueryParam &&
+      preSelectedComposerIdFromQueryParam != preSelectedComposerId
+    ) {
       setPreselectedComposerId(preSelectedComposerIdFromQueryParam);
     } else {
       const preselectPinboardHTMLElement: HTMLElement | null = document.querySelector(
         PRESELECT_PINBOARD_HTML_TAG
       );
-      if (preselectPinboardHTMLElement) {
-        setPreselectedComposerId(
-          preselectPinboardHTMLElement.dataset?.composerId
-        );
-        setComposerSection(
-          preselectPinboardHTMLElement.dataset?.composerSection
-        );
-      }
+      const newComposerId = preselectPinboardHTMLElement?.dataset?.composerId;
+      newComposerId !== preSelectedComposerId &&
+        setPreselectedComposerId(newComposerId);
+
+      const newComposerSection =
+        preselectPinboardHTMLElement?.dataset?.composerSection;
+      newComposerSection !== composerSection &&
+        setComposerSection(newComposerSection);
     }
   };
 

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -160,7 +160,10 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     } else {
       activePinboardsQuery.stopPolling();
     }
-  }, [isExpanded, activePinboardIds]);
+  }, [
+    isExpanded,
+    ...activePinboardIds, // spread required because useEffect only checks the pointer, not the contents of the activePinboardIds array
+  ]);
 
   const activePinboards: PinboardData[] =
     activePinboardsQuery.data?.getPinboardsByIds || [];


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 

When experimenting/working on #150 , @andrew-nowak astutely noticed a very high amount of AJAX requests in the Network tab of developer tools, specifically `getPinboardsByIds` GraphQL calls. We tracked this down to an oversight in our understanding of how the dependency list on React's `useEffect` hook works, where it does reference checking not deep object/array equality, as such the `getPinboardsByIds` refetch was being triggered (in that `useEffect` block) when ever the `activePinboardIds` array reference was being updated (which was happening very frequently) even though the values we not changing - the solution we found online was to `JSON.stringify` to make the value stable, however we found that spreading the `activePinboardIds` array into the dependency list had the same effect and was more elegant (and probably cheaper too).

Whilst there we also noticed a possible cause of unnecessary re-renders (although probably unrelated to this issue), which we've hopefully addressed by the change detection we've added before setting state relating to stuff  detected in the DOM of the host application (e.g. the preselected pinboard ID put there by composer).