### PR TITLE
more consistent scroll to bottom

### DIFF
--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -112,7 +112,6 @@ const maybeConstructPayloadAndType = (
 
 interface ItemDisplayProps {
   item: Item | PendingItem;
-  refForLastItem: React.RefObject<HTMLDivElement> | undefined;
   userLookup: { [email: string]: User } | undefined;
   userEmail: string;
   seenBy: LastItemSeenByUser[] | undefined;
@@ -121,7 +120,6 @@ interface ItemDisplayProps {
 
 export const ItemDisplay = ({
   item,
-  refForLastItem,
   userLookup,
   userEmail,
   seenBy,
@@ -146,7 +144,6 @@ export const ItemDisplay = ({
 
   return (
     <div
-      ref={refForLastItem}
       css={css`
         padding-bottom: ${space[1]}px;
         margin-bottom: ${space[1]}px;


### PR DESCRIPTION
When working on #148 (in particular a fix to some jankiness where preserving the scrollTop was required - see https://github.com/guardian/pinboard/pull/148#issuecomment-1214442562) I realised that setting `scrollTop` to max int was a more reliable way to scroll to the bottom of the chat (which we do in various scenarios). This PR does that and phases out the last item ref.