### PR TITLE
change timestamps colour to improve accessibility

### DIFF
--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -189,7 +189,7 @@ export const ItemDisplay = ({
       >
         <div
           css={css`
-            color: ${palette.neutral["46"]};
+            color: ${palette.neutral["20"]};
             ${agateSans.xxsmall({ lineHeight: "tight" })};
             margin-bottom: 2px;
           `}

--- a/client/src/seenBy.tsx
+++ b/client/src/seenBy.tsx
@@ -40,7 +40,7 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
     >
       <span
         css={css`
-          color: ${palette.neutral[46]};
+          color: ${palette.neutral[20]};
           margin-right: 5px;
           ${agateSans.xxsmall({ lineHeight: "tight" })}
         `}


### PR DESCRIPTION
## What does this change?
It changes the colour of timestamps from neutral.46 to neutral.20 to improve the contrast of text over the background from 4:5 to 11:6 (the minimum recommended by DAC is 5:2)

This is based on a recommendation from the Digital Accessibility Centre to help colour blind users. 

## Images
![Screenshot 2022-08-15 at 12 11 16](https://user-images.githubusercontent.com/45033520/184625270-1a294a00-3a54-4d8a-9821-87882be0fa9a.png)

Figma screenshot, as I can't run Pinboard locally yet

## Accessibility
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
