### PR TITLE
changed message colour for better contrast

### DIFF
--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -152,7 +152,7 @@ export const ItemDisplay = ({
         margin-bottom: ${space[1]}px;
         font-style: ${isPendingSend ? "italic" : "normal"};
         ${agateSans.small({ lineHeight: "tight" })};
-        color: ${palette.neutral[20]};
+        color: ${palette.neutral[7]};
         overflow-wrap: anywhere;
       `}
     >


### PR DESCRIPTION
## What does this change?
changes the colour of the message text to a darker tone (from neutral.20 to neutral.7) so they have better contrast against other elements of the panel that were recently changed (timestamp and seen by from neutral.46 to neutral.20)

## Images

From Figma (L before, R after)
![Screenshot 2022-08-16 at 13 53 37](https://user-images.githubusercontent.com/45033520/184884835-42a72492-0743-4436-9daa-0373491aa25f.png)

And CODE
![Screenshot 2022-08-16 at 13 56 38](https://user-images.githubusercontent.com/45033520/184885190-6522b094-cd1d-4726-8342-4a5b7489a7c6.png)

## Accessibility
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
