### PR TITLE
when sending message, lock input box and replace send button with spinner

### DIFF
--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -70,6 +70,7 @@ interface CreateItemInputBoxProps {
   allUsers: User[] | undefined;
   addUnverifiedMention: (user: User) => void;
   panelElement: HTMLDivElement | null;
+  isSending: boolean;
 }
 
 export const CreateItemInputBox = ({
@@ -81,6 +82,7 @@ export const CreateItemInputBox = ({
   sendItem,
   addUnverifiedMention,
   panelElement,
+  isSending,
 }: CreateItemInputBoxProps) => (
   <div
     css={css`
@@ -91,6 +93,7 @@ export const CreateItemInputBox = ({
     `}
   >
     <ReactTextareaAutocomplete<User>
+      disabled={isSending}
       trigger={
         allUsers
           ? {

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -12,6 +12,7 @@ import { composer } from "../colours";
 import SendArrow from "../icons/send.svg";
 import { buttonBackground } from "./styling";
 import { TelemetryContext, PINBOARD_TELEMETRY_TYPE } from "./types/Telemetry";
+import { SvgSpinner } from "@guardian/source-react-components";
 
 interface SendMessageAreaProps {
   payloadToBeSent: PayloadAndType | null;
@@ -48,7 +49,9 @@ export const SendMessageArea = ({
     return !!message.match(gridUrlRegex);
   };
 
-  const [sendItem] = useMutation<{ createItem: Item }>(gqlCreateItem, {
+  const [sendItem, { loading: isItemSending }] = useMutation<{
+    createItem: Item;
+  }>(gqlCreateItem, {
     onCompleted: (sendMessageResult) => {
       onSuccessfulSend({
         ...sendMessageResult.createItem,
@@ -98,6 +101,7 @@ export const SendMessageArea = ({
         allUsers={allUsers}
         addUnverifiedMention={addUnverifiedMention}
         panelElement={panelElement}
+        isSending={isItemSending}
       />
       <button
         css={css`
@@ -121,14 +125,18 @@ export const SendMessageArea = ({
           }
         `}
         onClick={() => sendItem()}
-        disabled={!message && !payloadToBeSent}
+        disabled={isItemSending || !(message || payloadToBeSent)}
       >
-        <SendArrow
-          css={css`
-            width: 18px;
-            height: 16px;
-          `}
-        />
+        {isItemSending ? (
+          <SvgSpinner />
+        ) : (
+          <SendArrow
+            css={css`
+              width: 18px;
+              height: 16px;
+            `}
+          />
+        )}
       </button>
     </div>
   );


### PR DESCRIPTION
When experimenting on https://github.com/guardian/pinboard/pull/150, I noticed that when there's latency sending the item, the UI is not locked 😬 - now the input box is disabled during sending and the send button is replaced with a spinner (from source)

![sending_spinner](https://user-images.githubusercontent.com/19289579/184905505-757ddf54-651f-433f-986f-6d2ed86db608.gif)
