### PR TITLE
upgrade to AWS CDK V2

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -4,7 +4,7 @@
   "actions": [
     {
       "action": "pinboard-cloudformation",
-      "path": "cdk/cloudformation.yaml",
+      "path": "cdk/cdk.out/PinBoardStack.template.json",
       "compress": false
     },
     {

--- a/cdk/cdk.ts
+++ b/cdk/cdk.ts
@@ -1,5 +1,9 @@
-import * as cdk from "@aws-cdk/core";
 import { PinBoardStack } from "./stack";
+import { App, DefaultStackSynthesizer } from "aws-cdk-lib";
 
-const app = new cdk.App();
-new PinBoardStack(app, "PinBoardStack");
+const app = new App();
+new PinBoardStack(app, "PinBoardStack", {
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false,
+  }),
+});

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -7,27 +7,17 @@
   "scripts": {
     "test": "tsc --noEmit & jest",
     "watch": "tsc --noEmit --watch & jest --watch",
-    "build": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts' > cloudformation.yaml",
+    "build": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts'",
     "update-snapshot": "jest -u"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.147.0",
-    "@types/node": "^14.14.7",
-    "aws-cdk": "1.147.0",
-    "ts-node": "^9.0.0"
+    "@types/node": "14.14.7",
+    "ts-node": "9.0.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "1.147.0",
-    "@aws-cdk/aws-appsync": "1.147.0",
-    "@aws-cdk/aws-dynamodb": "1.147.0",
-    "@aws-cdk/aws-ec2": "1.147.0",
-    "@aws-cdk/aws-events": "1.147.0",
-    "@aws-cdk/aws-events-targets": "1.147.0",
-    "@aws-cdk/aws-iam": "1.147.0",
-    "@aws-cdk/aws-lambda": "1.147.0",
-    "@aws-cdk/aws-lambda-event-sources": "1.147.0",
-    "@aws-cdk/aws-s3": "1.147.0",
-    "@aws-cdk/aws-ssm": "1.147.0",
-    "@aws-cdk/core": "1.147.0"
+    "@aws-cdk/aws-appsync-alpha": "2.38.1-alpha.0",
+    "aws-cdk": "2.38.1",
+    "aws-cdk-lib": "2.38.1",
+    "constructs": "10.1.83"
   }
 }

--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -1,33 +1,33 @@
 import {
+  App,
   CfnMapping,
   CfnOutput,
   CfnParameter,
-  Construct,
   Duration,
   Fn,
   Stack,
   StackProps,
   Tags,
-} from "@aws-cdk/core";
-import * as lambda from "@aws-cdk/aws-lambda";
-import * as S3 from "@aws-cdk/aws-s3";
-import * as iam from "@aws-cdk/aws-iam";
-import * as ssm from "@aws-cdk/aws-ssm";
-import * as apigateway from "@aws-cdk/aws-apigateway";
-import * as appsync from "@aws-cdk/aws-appsync";
-import * as db from "@aws-cdk/aws-dynamodb";
-import * as acm from "@aws-cdk/aws-certificatemanager";
-import * as ec2 from "@aws-cdk/aws-ec2";
-import * as events from "@aws-cdk/aws-events";
-import * as eventsTargets from "@aws-cdk/aws-events-targets";
+  aws_lambda as lambda,
+  aws_s3 as S3,
+  aws_iam as iam,
+  aws_ssm as ssm,
+  aws_apigateway as apiGateway,
+  aws_dynamodb as db,
+  aws_certificatemanager as acm,
+  aws_ec2 as ec2,
+  aws_events as events,
+  aws_events_targets as eventsTargets,
+} from "aws-cdk-lib";
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import { join } from "path";
 import { APP } from "../shared/constants";
 import crypto from "crypto";
-import { DynamoEventSource } from "@aws-cdk/aws-lambda-event-sources";
+import { DynamoEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { ENVIRONMENT_VARIABLE_KEYS } from "../shared/environmentVariables";
 
 export class PinBoardStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: App, id: string, props?: StackProps) {
     super(scope, id, props);
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -254,16 +254,6 @@ export class PinBoardStack extends Stack {
         },
         xrayEnabled: true,
       }
-    );
-    pinboardAuthLambda.grantInvoke(
-      new iam.ServicePrincipal("appsync.amazonaws.com").withConditions({
-        ArnLike: {
-          "aws:SourceArn": pinboardAppsyncApi.arn,
-        },
-        StringEquals: {
-          "aws:SourceAccount": account,
-        },
-      })
     );
 
     const pinboardItemTableBaseName = "pinboard-item-table";
@@ -666,13 +656,13 @@ export class PinBoardStack extends Stack {
       }
     );
 
-    const bootstrappingApiGateway = new apigateway.LambdaRestApi(
+    const bootstrappingApiGateway = new apiGateway.LambdaRestApi(
       thisStack,
       bootstrappingLambdaApiBaseName,
       {
         restApiName: `${bootstrappingLambdaApiBaseName}-${STAGE}`,
         handler: bootstrappingLambdaFunction,
-        endpointTypes: [apigateway.EndpointType.REGIONAL],
+        endpointTypes: [apiGateway.EndpointType.REGIONAL],
         policy: new iam.PolicyDocument({
           statements: [
             new iam.PolicyStatement({
@@ -715,13 +705,13 @@ export class PinBoardStack extends Stack {
       }
     );
 
-    const bootstrappingApiDomainName = new apigateway.DomainName(
+    const bootstrappingApiDomainName = new apiGateway.DomainName(
       thisStack,
       `${bootstrappingLambdaApiBaseName}-domain-name`,
       {
         domainName,
         certificate: bootstrappingApiCertificate,
-        endpointType: apigateway.EndpointType.REGIONAL,
+        endpointType: apiGateway.EndpointType.REGIONAL,
       }
     );
 

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -48,6 +48,11 @@ Object {
     },
   },
   "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "SsmParameterValuepinboardsentryDSNC96584B6F00A464EAD1953AFF4B05118Parameter": Object {
       "Default": "/pinboard/sentryDSN",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -425,12 +430,28 @@ $util.toJson($ctx.result)",
             Object {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "pinboardgridbridgelambda79AD9656",
-                  "Arn",
-                ],
-              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "pinboardgridbridgelambda79AD9656",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "pinboardgridbridgelambda79AD9656",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -1214,12 +1235,28 @@ $util.toJson($ctx.result)",
             Object {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "pinboardworkflowbridgelambda30D4AA22",
-                  "Arn",
-                ],
-              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "pinboardworkflowbridgelambda30D4AA22",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "pinboardworkflowbridgelambda30D4AA22",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
             },
           ],
           "Version": "2012-10-17",
@@ -1310,28 +1347,6 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::Lambda::Function",
     },
-    "pinboardauthlambdaInvokeServicePrincipalappsyncamazonawscomE688F3A1": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "pinboardauthlambdaC1D899AE",
-            "Arn",
-          ],
-        },
-        "Principal": "appsync.amazonaws.com",
-        "SourceAccount": Object {
-          "Ref": "AWS::AccountId",
-        },
-        "SourceArn": Object {
-          "Fn::GetAtt": Array [
-            "pinboardappsyncapi9D519400",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
     "pinboardauthlambdaServiceRole8197EA98": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -1401,6 +1416,19 @@ $util.toJson($ctx.result)",
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "pinboardauthlambdaappsync13E2B14E": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "pinboardauthlambdaC1D899AE",
+            "Arn",
+          ],
+        },
+        "Principal": "appsync.amazonaws.com",
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "pinboardbootstrappinglambdaD2C487DA": Object {
       "DependsOn": Array [
@@ -1761,6 +1789,7 @@ $util.toJson($ctx.result)",
       "Type": "AWS::Lambda::Permission",
     },
     "pinboardbootstrappinglambdaapiAccountF1D904A1": Object {
+      "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "pinboardbootstrappinglambdaapi577E85F1",
       ],
@@ -1773,8 +1802,10 @@ $util.toJson($ctx.result)",
         },
       },
       "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
     },
     "pinboardbootstrappinglambdaapiCloudWatchRole71E5177D": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1822,6 +1853,7 @@ $util.toJson($ctx.result)",
         ],
       },
       "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
     },
     "pinboardbootstrappinglambdaapiDeploymentF3CA75CFfa18e3d3af308dd131f6627bd80d2597": Object {
       "DependsOn": Array [
@@ -3098,6 +3130,33 @@ $util.toJson($ctx.result)",
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }

--- a/cdk/test/stack.test.ts
+++ b/cdk/test/stack.test.ts
@@ -1,12 +1,10 @@
-import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert";
-import { App } from "@aws-cdk/core";
+import { App, assertions } from "aws-cdk-lib";
 import { PinBoardStack } from "../stack";
 
 describe("PinBoardStack's", () => {
   it("generated CloudFormation matches the snapshot", () => {
     const app = new App();
     const stack = new PinBoardStack(app, "PinBoardStack");
-    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    expect(assertions.Template.fromStack(stack)).toMatchSnapshot();
   });
 });

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
       cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: pinboard
-      templatePath: cloudformation.yaml
+      templatePath: PinBoardStack.template.json
 
   pinboard-bootstrapping-lambda-api:
     dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,811 +34,10 @@
   dependencies:
     tslib "~2.0.1"
 
-"@aws-cdk/assert@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.147.0.tgz#66ab7c5e868e4ccf891c62d212ddb3348eeec3ed"
-  integrity sha512-YMjimN4DUHe+VGjNLbDZYMv3isklQpfSY10BzdEW7+fn2g5/TkbJgwvUEEN3fyM9vPp/0daeCxcqHVlCdPCtzg==
-  dependencies:
-    "@aws-cdk/cloudformation-diff" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/assets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.147.0.tgz#4333e2de99a5c7c652276788e35e961623f0862c"
-  integrity sha512-Fz5PB/cXPCeQUk0eNPQkYzzSG7encauGLT7Hm/egIavP6EKwGYxxkmy90SOHSOYg3FXjZxi5+evbyhL+2NAgRw==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-acmpca@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-acmpca/-/aws-acmpca-1.147.0.tgz#275c380166f00806a653225e34f11ca9673eb0f2"
-  integrity sha512-2rZLCCe0AgzHnZjjunH6L0otP98AKSw0XO/m9UggJKBbDSnrna34RAbsk9QSo/EK2bm61cel2Co+7Cu4mWHnWQ==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-apigateway@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.147.0.tgz#c91164300004ec64ffb91072482b7c6296c1301b"
-  integrity sha512-dGA7+6kLV5g9XAD+hzhhRKUx3oxxTL77sxuwnlkOhxBI8SqTTDI4qWMRSgqv8UxBTJA+9LUsnZ+wAoCG5O7Drw==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-cognito" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-stepfunctions" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-applicationautoscaling@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.147.0.tgz#8949861ed25ff5832b5d2bc56291d178d49ee0f6"
-  integrity sha512-pplTpCdgP9EjjSCsoFW9vjTp2XywDb22pTX/LRuc0dt5DDFmWxeKJyGpBkdcMDtrc8F4zrBV+T3qFy6pLzKJkA==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-appsync@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync/-/aws-appsync-1.147.0.tgz#ce67fb31377f571ef9e18dbf36eff8ba4f502001"
-  integrity sha512-kEH9C3bAl7pQmvGeNs3AaJyBfNQsnoicBVb8dH/m5l35goCRmbPFTFCUu26yRAt6ms+g9JKvIB+t4jd2tkpt8w==
-  dependencies:
-    "@aws-cdk/aws-cognito" "1.147.0"
-    "@aws-cdk/aws-dynamodb" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-elasticsearch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-rds" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-common@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.147.0.tgz#994ecb12fd5c6ac39d973212d25f5c5b39558dce"
-  integrity sha512-NyzmbXP51rbK0/UPt6jy5BQqAfZrShABwMLPEhqeLRCkQqMmA2QkmkGebbTLWoCC1Kg5APsyx0Dm1/Wi1DNcCA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling-hooktargets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.147.0.tgz#489a40db16e39a9e1d9887dd8de9f6ddca868500"
-  integrity sha512-SVJ/7jkad41EojtzouXDvNMEorAsImIqJhthEb5MwRVPL0BmffzN/xnwEcWRYsS4Vef23ISoxcDFLmU/6Ft40g==
-  dependencies:
-    "@aws-cdk/aws-autoscaling" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-autoscaling@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.147.0.tgz#d0580f8fa1b0b0a2760ef85045a2dd20a0c8fe42"
-  integrity sha512-MZrWcICu54LF0CME2ISaIUm+uwmNethvvR2Qt9igLV5u3RI7MV8Aqcelz7Jko0R9Mhs+hC4uB++MmjHApvZKsg==
-  dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-certificatemanager@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.147.0.tgz#ee78ca8722c7bd623cfd1e23eab3877e70a34811"
-  integrity sha512-g46IR2ymXE/o/4txjvFxGJntEhL8BCUjRKE1g/iS/W4OgocN48xFWVWGcZlr3htdUJpsdIKpZpd2LB6WiKGw3A==
-  dependencies:
-    "@aws-cdk/aws-acmpca" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-route53" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudformation@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.147.0.tgz#dfd2eb59870692046818a29baf5b042fd40cd202"
-  integrity sha512-3qmi6RLY+y2GslTeyCQaIGOPs50PLsDLVkV5Lwo+S9ihGPmMWYvt3+kIlIFYSBpaoLR8eKqTmuvQG5ruq2Y9pA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudfront@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.147.0.tgz#452cc4dc0ee1054ac40db966b133de66c1c12c07"
-  integrity sha512-UuYhX4n0YGocFoQnHa9qDaIEoI0G5nIg5ZIx101k0xnrX9YIz+70pu+YiLUqz08vwkRd0HZ0HREYrQHY8u6BFg==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-ssm" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cloudwatch@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.147.0.tgz#f559c749acdfab1417339324d2bcbd1f1916a748"
-  integrity sha512-wyGbnzzCfULzOwNiqSPrDZPigy6svOcnZwUheu6dmzL7qxo1UHVj2hVCjTLbN7AtBx9WG3Rs70C6+WTqXQnYmQ==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codebuild@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.147.0.tgz#6d72ae36456664c59c37da12179ebc4a2306f223"
-  integrity sha512-QhBFJGxJhGcyBAx0/RTcqx0jMRyl8orqW2XDf3fs6E7H/bXjJjz168suHKb2OHN+21ZRYnAzxIDqyaYHzKr/Vg==
-  dependencies:
-    "@aws-cdk/assets" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-codecommit" "1.147.0"
-    "@aws-cdk/aws-codestarnotifications" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-ecr" "1.147.0"
-    "@aws-cdk/aws-ecr-assets" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-    yaml "1.10.2"
-
-"@aws-cdk/aws-codecommit@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.147.0.tgz#d1cb694230f159039c69ec1c585d12b3bc131982"
-  integrity sha512-+2Z96JI0VYegoBdAkr/jwGyW4m4+KDcN0lzWlN0ZhUOAB/bTMz0XLMg5YmTEZSUXsytaOWI1yBbPDTGVtQ2s+Q==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codeguruprofiler@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.147.0.tgz#3c303be558b1fd1fea227a31402712e4c37eb929"
-  integrity sha512-ykEENwhVKCI7WNIm2AjmiT2r+FxpNjt4tXdzWYEviJUr4h4LWnae7IHgfVPDeUXYZaEXnaajvAxXMkTROUJxAA==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codepipeline@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.147.0.tgz#75c6ce421e3b80efa8ad86cebecf649b1166a5fa"
-  integrity sha512-zX5ZRgvc5RaACcJqwhhtky1f/KW0OuT6jLyCaDhB7atakkv5e669Ry44pK1QLE21/eCHG//4h78VxuHo4T02PA==
-  dependencies:
-    "@aws-cdk/aws-codestarnotifications" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-codestarnotifications@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.147.0.tgz#20582ad202236835fd42498f3a2379435d6848b0"
-  integrity sha512-+WOLDECaq7+fI5gIUJCi+svfHMC8+mfpL8hrV0a0rubTV3mHFoHv/vcdwYK5lW8X4PgfdWKbGUeBHoVweuIVBA==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-cognito@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cognito/-/aws-cognito-1.147.0.tgz#00c99dca4a4bc5dd4a52b0ba77ef0dfff7613f39"
-  integrity sha512-i1DzRBVxDx4OQDj/h3tqowYxyy+hc6lgvdK7yoqNYlF+9qL8nvOF/Gqng9JjJ3WsdEh3k/SPiOtHw4LsbrGo4A==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-    punycode "^2.1.1"
-
-"@aws-cdk/aws-dynamodb@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.147.0.tgz#14dea1b7ccbe8f985a17535fa35fe742716d54cd"
-  integrity sha512-+uae79csAi8Gt+2o5PLSLSkgx3jo1bUHsnEmNUip/sDEaHGP+bhoZAmOMj38mZwiN6Tj91uibEKU9MMquvDGYQ==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kinesis" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ec2@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.147.0.tgz#6bbddf4c239bfe2ab92372a00cadcd39bc9d1794"
-  integrity sha512-rTb3BDrkog388k+OJnYWBltbjAfH8f7+NuXdlaxXyWCzl3yWqzHfEYVGUUQ6WpWZd7MiogOpL5JUY4e+Ch+SXw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-ssm" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecr-assets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.147.0.tgz#cb3a8be97534a3619edccf5cc2b4afc0da5d4262"
-  integrity sha512-04CpHNgBZ6el8Z9cH06kRyqK7QyazlF0AJVi2yIs1Xcg7gt4zh/P0mUneEW3o7Wy4NQeOQYmKC7IoPht6qfB+A==
-  dependencies:
-    "@aws-cdk/assets" "1.147.0"
-    "@aws-cdk/aws-ecr" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecr@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.147.0.tgz#335c892900c0e17276503eae4e2797f5877f1b3b"
-  integrity sha512-vwcupBCw3hoCS8tjoJHiYsFJ2cVeCr/4a/l2q12xZH0oyf9qMZye0cfIdZqIwRVABVgnbrcAH9eZZf8mvCb1vQ==
-  dependencies:
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ecs@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.147.0.tgz#e66f0e67872898ad802e47ab37e0f5c2f28c0e35"
-  integrity sha512-YwYh50p3YYlQJrcF/DkvP8Q47zlYGn4B4WlqiNh6fGc70/QCXHziEszoTn5Bqy7HYbsxCfiGHKUZ8ROLYWxPXg==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.147.0"
-    "@aws-cdk/aws-autoscaling" "1.147.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.147.0"
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-ecr" "1.147.0"
-    "@aws-cdk/aws-ecr-assets" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-route53" "1.147.0"
-    "@aws-cdk/aws-route53-targets" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/aws-servicediscovery" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/aws-ssm" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-efs@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-efs/-/aws-efs-1.147.0.tgz#1c791feeb28a96a8b2b57010422ea3dbedec1b8b"
-  integrity sha512-gAi9vUBrvGOdLNqP7ORlgsIn4ZhLJQW1bK8vYrYpSMLDcTUf2kyo/xVoLMSm3YQ7UG75CrRqaKpSTBKhgMkRYg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticloadbalancing@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.147.0.tgz#593d59603e9f1b99793913aa5d674f2274337e37"
-  integrity sha512-wwfxogTmWpYEcMSZJLFlLLkZBaiLTgTVMqgDOfmAdOWJA8PlYkhUJPMcpvPMc/5m5ibz+qlZUjwAcXG9cqGTDw==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticloadbalancingv2@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.147.0.tgz#2975142617e89364aeba8c69fbc5213e42e178e3"
-  integrity sha512-TvgaD6qEbWPZ3Ryx6jUYO5ivEwSk5FfBgD9pXfYc3x1NaD6zvPK0NCv8uoR0f8+i0xUfQqV3DONpVxkvgYKEPA==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-elasticsearch@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticsearch/-/aws-elasticsearch-1.147.0.tgz#5450d2ed3691bf23cb39c6a7edb6e06c6d99c548"
-  integrity sha512-ML/7riDHFa3bqFbVPmuEfCKROZjVnXF8IFzOCt0lwd34gXYrhsyNlabYBtb9ymYOxql/NJOyEXsT0Lk6hR2BIA==
-  dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-route53" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events-targets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.147.0.tgz#fa73bf989eb7a088c6d55b213cd409a12b54b306"
-  integrity sha512-E4ld+SWk2LkO1+rA+bMwUm/WrvTKDzfcrcZodQuYkdp7hJBHQgSGQmhO3pyC/s+1UeMvtv+eBHYsia3v1EKgiQ==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.147.0"
-    "@aws-cdk/aws-autoscaling" "1.147.0"
-    "@aws-cdk/aws-codebuild" "1.147.0"
-    "@aws-cdk/aws-codepipeline" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-ecs" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kinesis" "1.147.0"
-    "@aws-cdk/aws-kinesisfirehose" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/aws-stepfunctions" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-events@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.147.0.tgz#da5adcb24e34c74ccbd88507e62640376126a7b7"
-  integrity sha512-zTwcs6pwMJSBipW4KNw75DjUqzMSeqBglGpgI3GAXjnqWODiZJ5E6OdsIMqkd8OyvZ+fvbNhNbWAN67iqcbI1w==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-globalaccelerator@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.147.0.tgz#ad3e1e11c62f796d70438ebc4e6641b9e350d329"
-  integrity sha512-JzW9vcmUsBdyKki4NajeWK8OLZfwd3HQ1uuHNfrRBw2RA8C5/YVy7BO8mbPFxsK0G3EUCvPGEZhYTyTlLiDURg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-iam@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.147.0.tgz#54382c9948cf71ba782b86ff77cfca413e5cea4f"
-  integrity sha512-25YwRaXiOmlI1YZ+CquR7vru59S+Wo1VlAsOnpZpzQ9RJiSgleOL6Qquw1veTylDK7xp1pijUhQdevQ8GUuwFA==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesis@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesis/-/aws-kinesis-1.147.0.tgz#e45bef8dd63d4e89bdb1284217f941c21c155213"
-  integrity sha512-Y+t3kdsb5qPsKg59bhQPlZfSIDfw89NbppkEdC7aLlvGzdWbBTv3hK3J3vRrSH4KLUYFaC/ylb9Ht6ZkEtfqEA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kinesisfirehose@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.147.0.tgz#7d701c51c6b5d93f3b99324ac5f54de43d6f164f"
-  integrity sha512-Q7xcreJeGrRPml+V1agH4nrlrvJR5R/AYzVpewAKpz/Gc8hPC0BSsI8q6zU6IO3BlSxP7m7kVaTk95qrt7M5Tw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kinesis" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-kms@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.147.0.tgz#6563efc32e1f55a3adb810964dd96342beb053cf"
-  integrity sha512-O/BeiPXmWqETZKHgy1kYqcbMiMUVaC1BmB+zZnrk5j5Aivb19H9+1wLQ0uuXWQ8wfsrNKsg+nsjfiDGhGA71Qg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-lambda-event-sources@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-event-sources/-/aws-lambda-event-sources-1.147.0.tgz#2121022e978e62b0195204b4c3f33611ee95f2f6"
-  integrity sha512-Pj8Wl4PLq/16NLkCtqxZqBK+HKhCGyW+vG1XaOOHBImcpriZhcibfd/PZ2ohLdelbSY5p06v/oJ7i2rL/HD85g==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.147.0"
-    "@aws-cdk/aws-dynamodb" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kinesis" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-notifications" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-lambda@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.147.0.tgz#ca63d7da9b3c5bd89f2bad960a93ebc47d1cc678"
-  integrity sha512-zAU/jPN7zz/FNFBZCxq93iQuQqDMXVa8+DYay+p0/z+zivUZMyi9078xy8TrnrG59CZTiGiIDYMbmZOj2m5k6w==
-  dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.147.0"
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-codeguruprofiler" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-ecr" "1.147.0"
-    "@aws-cdk/aws-ecr-assets" "1.147.0"
-    "@aws-cdk/aws-efs" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/aws-signer" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-logs@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.147.0.tgz#f9bc0bf0cb9fea97d3d8f1ecc7708227751e19a0"
-  integrity sha512-Rim34ijoHB+0KKdmURW3hqZj8GbgkUwxcU8MvlqAyFJtb2Ou0bq8F1drmEqC0OTV2cymlNLdFl6VqE8t0vkTMA==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-s3-assets" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-rds@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-rds/-/aws-rds-1.147.0.tgz#19210dd96e7743a9c0dc44b170fd12db113128a9"
-  integrity sha512-QjjXMGI1UsPy/sh3qNzM7W2zonIZhrxpWudsuld9hforOSVJF1ELoGlUNMJoV6psw2EB6bD2n6dRYIc6YdZM7A==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-secretsmanager" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53-targets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.147.0.tgz#aaa049fafa07b152ff10999dc588a38c1abdb5ce"
-  integrity sha512-b7xinT/0/7UY0wkkeB30QCYMSmIcm2UAJR5fE3YtKiAyS0Xp8n1ADSPyVeafu6/E4/o3MyOOuXvBhFy1/Q4Tug==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.147.0"
-    "@aws-cdk/aws-cloudfront" "1.147.0"
-    "@aws-cdk/aws-cognito" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.147.0"
-    "@aws-cdk/aws-globalaccelerator" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-route53" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-route53@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.147.0.tgz#4cc277b23fa5fe3060bee55bac361e49ea66299c"
-  integrity sha512-qksNZa/RgRqHlkwYqCdTqMt9invUk5hoMlZSlFjH0o6p70Xhr8upAzOuIbEPOxxcOXethdRmfyzrrceHud30mg==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/custom-resources" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-assets@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.147.0.tgz#c5cdb56f8df307f53c74c7cb350cca73063b45ac"
-  integrity sha512-7qRsjsqbLZKsGmwPzA3bMqnVd7bcKsOZEGSbl5UoY2U9UaMgOX5Lev53dDsh4qW9QSwXm0qBJTDeJwRrHfGaLQ==
-  dependencies:
-    "@aws-cdk/assets" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3-notifications@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.147.0.tgz#9ad1b5664089de2f4a2fd29ff0fb4a216ffa51b5"
-  integrity sha512-J7krYvbO4GOifRRaANGpYD0g35iR11LNOWT+dqK/RFbBOQwvl4sqBW9wpdujGMCkNhd44Hh+X/+wdwqVGLwxUg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-s3@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.147.0.tgz#76ccbd9d5900a8e792bbbe6e993d9e4ab17a06b7"
-  integrity sha512-vkk8hy8Utpximxx5k7HXM+VBYa+63xIg1N669FZ7rKfVEZ/H3ZEezRzPG9b5pNDwk4w6nh0VfYB7Ckgj/+lKxw==
-  dependencies:
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sam@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.147.0.tgz#06add93f4bb2cde742bf39bbcba668449616da59"
-  integrity sha512-izUhQa57eWVDHy8U3JaJ2g27pkDEuzLcnciVeW53/vIA7gVF9LVYW9Oy2nuPkdJOcuAWWuSHzhFW3NoYw9mx6g==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-secretsmanager@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.147.0.tgz#7e43c051fddb466573b6f4134416a1b6452365fc"
-  integrity sha512-udj7AN8J38kKLXDMfyEqercmtJKF09yqLdmas0XtlRacl+qw7MNkAWQPWEOQ8IOlZRGcPZ83DLAdYrQE++RoEw==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-sam" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-servicediscovery@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.147.0.tgz#8b7348376f40645f6d357fa40408cc46655266de"
-  integrity sha512-AKDn/jxM3jv/8iSMAa98ZC8cl37kWU66I/E7gClNPP1SeprEiQUl8M4hEjLA4e29JyZj1afeTl5GBMK5KC95EA==
-  dependencies:
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.147.0"
-    "@aws-cdk/aws-route53" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-signer@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-signer/-/aws-signer-1.147.0.tgz#90686cf3a66c40cf39ba505757a48d8b5bea094b"
-  integrity sha512-N42OxAqHXXNITurUBBddbWlzcr4PiXR7gM1gV9YvCI163eZUuKREuqtfhD8rmBAjMp6TJVDna3gAaySY+zNoBA==
-  dependencies:
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns-subscriptions@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.147.0.tgz#3b96c21cd9beeec1fd1297e2ead7f8916c04be01"
-  integrity sha512-MDfGqQddrB77+fHVAZYQYq9F47FuXQMBd0sOQwueLSShwIJQWyH3Fei2fZ2sH4M/N81fjSpHJ5VscPtl1T9lfw==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sns@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.147.0.tgz#d452fd2b0a87957173d1e7c9e652fb2a0caf398a"
-  integrity sha512-j3eQetou0V/QRSvnP8G6zLryFN481BVEP4pkDjXmW4e/5tdHhj4Diy12SbrY8niwwzVj9gftsDmu9WEk+rAHQw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-codestarnotifications" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/aws-sqs" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-sqs@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.147.0.tgz#e7b2913e6c1d7780a4d43624c2be3dfc663bcc65"
-  integrity sha512-76uRyNQJjTT8K82vgXfK4yCvFyt6YvKOVsSiOPtNK0ncu1dljgEIneIlP0pQIvyWODEV6Sgjh6z25yh6qP8KFw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-ssm@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.147.0.tgz#0d3b6f3a68e4f09519a8ea552679a031db1b92b5"
-  integrity sha512-/FHY5sIEQR+EO3CqZ9zA/7CnaGBcmSdsaXsj/sKgPkmUoV2WFFJYlHpfs9AacpNQw9v+zWiSdsn5rOK/UPJvGg==
-  dependencies:
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-kms" "1.147.0"
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/aws-stepfunctions@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.147.0.tgz#ebd5ade401d78463876ca3507f0801eab699da38"
-  integrity sha512-+4fytzNZlI42O2bnTCV4b5bTO3N68fbOnea0Fhc6VOl31HBtaGphMQGCAd9qWZE4LH40CsmXv3W/W6VK9fVZSw==
-  dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.147.0"
-    "@aws-cdk/aws-events" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-s3" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/cfnspec@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.147.0.tgz#ba307faa5705d4e91409369affe4a55b4ca2dbc0"
-  integrity sha512-EHDLrrCxmgh47FmD6xVO2DC9avVigOZZwqHErlB4Ci9PhxO8MYXSnv8muyA2sSayDf7ThaxRAeJbJmqmOikIUQ==
-  dependencies:
-    fs-extra "^9.1.0"
-    md5 "^2.3.0"
-
-"@aws-cdk/cloud-assembly-schema@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.147.0.tgz#0c9cd4f87f4f099e58616bbe482d1a5fa5d8ee9d"
-  integrity sha512-ht8ehqrn8WhvpOJYbgBGVeUm0R77T0eTH4ryDX+Tf5FvNal0SuQ9Alby4ujaP7JvnI04KT90EYPwxEXBkpQzPg==
-  dependencies:
-    jsonschema "^1.4.0"
-    semver "^7.3.5"
-
-"@aws-cdk/cloudformation-diff@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.147.0.tgz#6a28bd80c44052f2018a2a13f625a45b88abefaa"
-  integrity sha512-RfG5dNTqNFZXf2nRKP0x1vNCImkxcAH29VDGyQ8DfRcCiWejTQyJ5yrPaSFhSm4AEjxbICaIJvOCSVqdZxgJaA==
-  dependencies:
-    "@aws-cdk/cfnspec" "1.147.0"
-    "@types/node" "^10.17.60"
-    chalk "^4"
-    diff "^5.0.0"
-    fast-deep-equal "^3.1.3"
-    string-width "^4.2.3"
-    table "^6.8.0"
-
-"@aws-cdk/core@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.147.0.tgz#cf71432a3cd37d3bb30c3628bf4652e3ce673b8d"
-  integrity sha512-mh4mA1NHKrHVVIKsOTnpgnimZnhXPL7YIy/wFPgjUjzqdACZvflBK0W0yB+8IJIAaqL2ft5F0fGKaDoFVVhq6w==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    "@aws-cdk/cx-api" "1.147.0"
-    "@aws-cdk/region-info" "1.147.0"
-    "@balena/dockerignore" "^1.0.2"
-    constructs "^3.3.69"
-    fs-extra "^9.1.0"
-    ignore "^5.2.0"
-    minimatch "^3.1.2"
-
-"@aws-cdk/custom-resources@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.147.0.tgz#22267b744d25f0cc2e0fea3431ef7d4209ee1b86"
-  integrity sha512-RbIFCHlXfxE59hYG8Uod/fh2Ids/nUyO/Z8KFQG0y+anyHEExbor9QDuvTDXncgXbQgXaog0UNsmWGEfaBbbBw==
-  dependencies:
-    "@aws-cdk/aws-cloudformation" "1.147.0"
-    "@aws-cdk/aws-ec2" "1.147.0"
-    "@aws-cdk/aws-iam" "1.147.0"
-    "@aws-cdk/aws-lambda" "1.147.0"
-    "@aws-cdk/aws-logs" "1.147.0"
-    "@aws-cdk/aws-sns" "1.147.0"
-    "@aws-cdk/core" "1.147.0"
-    constructs "^3.3.69"
-
-"@aws-cdk/cx-api@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.147.0.tgz#a781bb2c4984d6c95f5c950451994701d4d86f8f"
-  integrity sha512-UUZubdiv3As/pT70MHA76bua3w+fhfFFPve71OFkqiF7jQKD92Tdii7ZqEDByTZp/OWNbdE5msZSEru5EsXJjw==
-  dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.147.0"
-    semver "^7.3.5"
-
-"@aws-cdk/region-info@1.147.0":
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.147.0.tgz#072411858b187d2284416402ab5863b752e7e44a"
-  integrity sha512-mSCQnR3fLwEqLF1G7VFQOfigIsA27uOVW0apViu3W5Rur0ERXGpcYM61PiEjt3T9cGV0N1uiPrfMY4RwIy2jfQ==
+"@aws-cdk/aws-appsync-alpha@2.38.1-alpha.0":
+  version "2.38.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync-alpha/-/aws-appsync-alpha-2.38.1-alpha.0.tgz#b7acd00430fefe89a05856bef9e721f435ac76a8"
+  integrity sha512-YtUJjv63Efed3rGgu1dCGDbThzcy6R+UF+kGj3voLzhEX53HREa8+P6M8/EExUyc9pj2vWFHlEKALGEz4bCdGg==
 
 "@aws-crypto/sha256-js@^1.2.0":
   version "1.2.2"
@@ -3164,15 +2363,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^14.14.7":
+"@types/node@*", "@types/node@14.14.7":
   version "14.14.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.7.tgz#8ea1e8f8eae2430cf440564b98c6dfce1ec5945d"
   integrity sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==
-
-"@types/node@^10.17.60":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3979,10 +3173,25 @@ aws-appsync-subscription-link@^3.0.9:
     debug "2.6.9"
     url "^0.11.0"
 
-aws-cdk@1.147.0:
-  version "1.147.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.147.0.tgz#0534627ff201d717d37212b7de084fb926119748"
-  integrity sha512-ZBtZQjvDbgkFlZg6z7qm5ryMy2B1t+B2000avWnkGc0TQuv7YjdK6j+6uoDFKvsiIYepKKMgAX04scEimbbaGw==
+aws-cdk-lib@2.38.1:
+  version "2.38.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.38.1.tgz#e96ee1362c86260786b3d808f593ca5edd813b29"
+  integrity sha512-vEgJBUzL1yqlSMYGjipl+eRwy900x3RmbVzTcxKdCZvhtBMQ1hqJAMgVswvoyA5EnvfELLlz9ufm+qdKGs9DxQ==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^9.1.0"
+    ignore "^5.2.0"
+    jsonschema "^1.4.1"
+    minimatch "^3.1.2"
+    punycode "^2.1.1"
+    semver "^7.3.7"
+    yaml "1.10.2"
+
+aws-cdk@2.38.1:
+  version "2.38.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.38.1.tgz#285273b5507241712bcc1e5b40eb05a21f3bebfd"
+  integrity sha512-bIHRCkmbXBmJWw1Gq5UsAUUYKABuE/ah1iAA14hXLS8+9AJlF/Ptn+NsUCt9K5v17cRqtUoeaOAMAPrZs8l+YA==
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -4475,6 +3684,11 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
+case@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -4508,7 +3722,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4, chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4525,11 +3739,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
 chokidar@^3.4.3, chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
@@ -4819,10 +4028,10 @@ constant-case@3.0.3, constant-case@^3.0.3:
     tslib "^1.10.0"
     upper-case "^2.0.1"
 
-constructs@^3.3.69:
-  version "3.3.71"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.71.tgz#5a3e968de484ad327bc2650aa4a7f37a39834ac5"
-  integrity sha512-3KFtTsA7OV27m/+pJhN4iJkKzHbPIPvyvEX5BQ/JCAWjfCHOQEVpIgxHLpT4i8L1OFta+pJrzcEVAHo6UitwqA==
+constructs@10.1.83:
+  version "10.1.83"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.1.83.tgz#45c6f33b20d76b5f3132cf51362a8e267a8504da"
+  integrity sha512-SXwMtiEMgM5Nmzubk2lHXVCHrSLwzNGyz7ZiV5piLUzmzbm7WQl/o5gzSJTUDPbNa/2JcY3lXYeb1AcCM+2GuQ==
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -4966,11 +4175,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 css-in-js-utils@^2.0.0:
   version "2.0.1"
@@ -5278,11 +4482,6 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -7157,7 +6356,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.6:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -8056,10 +7255,10 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonschema@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
-  integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
+jsonschema@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
@@ -8525,15 +7724,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-md5@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -10169,10 +9359,10 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -10893,7 +10083,7 @@ sync-fetch@0.3.0:
     buffer "^5.7.0"
     node-fetch "^2.6.1"
 
-table@^6.0.4, table@^6.8.0:
+table@^6.0.4:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
   integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
@@ -11147,7 +10337,7 @@ ts-node-dev@^1.0.0, ts-node-dev@^1.1.8:
     ts-node "^9.0.0"
     tsconfig "^7.0.0"
 
-ts-node@^9, ts-node@^9.0.0:
+ts-node@9.0.0, ts-node@^9, ts-node@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
   integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==


### PR DESCRIPTION
AWS CDK v1 has entered maintenance mode on June 1st 2022.

![image](https://user-images.githubusercontent.com/19289579/185913335-7bf75b4d-5c50-445f-9e49-8ef5e3afbcbf.png)

NOTE: we'll be adopting https://github.com/guardian/cdk in a future PR (soonish) as it wasn't mature when this CDK stack was first created.