### PR TITLE
ensure clicking a desktop notification opens in correct environment end expand the correct pinboard

### DIFF
--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -30,14 +30,10 @@
     >
     <h3>Pinboard pre-selection</h3>
     <ul>
-      <h4>
-        via query param (for composer ID <code>54f2d2fee4b011581586e710</code>)
-      </h4>
+      <h4>via query param (for workflow/pinboard ID <code>14748</code>)</h4>
       <ul>
         <li>
-          <a href="?pinboardComposerID=54f2d2fee4b011581586e710"
-            >?pinboardComposerID=54f2d2fee4b011581586e710</a
-          >
+          <a href="?pinboardId=14748">?pinboardId=14748</a>
         </li>
         <li>
           <a href="?"><em>REMOVE QUERY PARAM</em></a>

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -32,11 +32,13 @@ import {
   IPinboardEventTags,
 } from "./types/Telemetry";
 import { IUserTelemetryEvent } from "@guardian/user-telemetry-client";
+import {
+  EXPAND_PINBOARD_QUERY_PARAM,
+  OPEN_PINBOARD_QUERY_PARAM,
+} from "../../shared/constants";
 
 const PRESELECT_PINBOARD_HTML_TAG = "pinboard-preselect";
-const PRESELECT_PINBOARD_QUERY_PARAM = "pinboardComposerID";
 const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
-export const EXPAND_PINBOARD_QUERY_PARAM = "expandPinboard";
 
 interface PinBoardAppProps {
   apolloClient: ApolloClient<Record<string, unknown>>;
@@ -53,19 +55,19 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
 
   const queryParams = new URLSearchParams(window.location.search);
   // using state here but without setter, because host application/SPA might change url
-  // and lose the query param but we don't want to lose the preselection
-  const [preSelectedComposerIdFromQueryParam] = useState(
-    queryParams.get(PRESELECT_PINBOARD_QUERY_PARAM)
+  // and lose the query param, but we don't want to lose the preselection
+  const [openPinboardIdBasedOnQueryParam] = useState(
+    queryParams.get(OPEN_PINBOARD_QUERY_PARAM)
   );
 
   const [preSelectedComposerId, setPreselectedComposerId] = useState<
     string | null | undefined
-  >(preSelectedComposerIdFromQueryParam);
+  >(null);
 
   const [composerSection, setComposerSection] = useState<string | undefined>();
 
   const [isExpanded, setIsExpanded] = useState<boolean>(
-    !!preSelectedComposerIdFromQueryParam || // expand by default when preselected via url query param
+    !!openPinboardIdBasedOnQueryParam || // expand by default when preselected via url query param
       queryParams.get(EXPAND_PINBOARD_QUERY_PARAM)?.toLowerCase() === "true"
   );
   const expandFloaty = () => setIsExpanded(true);
@@ -76,24 +78,17 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
     );
 
   const refreshPreselectedPinboard = () => {
-    if (
-      preSelectedComposerIdFromQueryParam &&
-      preSelectedComposerIdFromQueryParam != preSelectedComposerId
-    ) {
-      setPreselectedComposerId(preSelectedComposerIdFromQueryParam);
-    } else {
-      const preselectPinboardHTMLElement: HTMLElement | null = document.querySelector(
-        PRESELECT_PINBOARD_HTML_TAG
-      );
-      const newComposerId = preselectPinboardHTMLElement?.dataset?.composerId;
-      newComposerId !== preSelectedComposerId &&
-        setPreselectedComposerId(newComposerId);
+    const preselectPinboardHTMLElement: HTMLElement | null = document.querySelector(
+      PRESELECT_PINBOARD_HTML_TAG
+    );
+    const newComposerId = preselectPinboardHTMLElement?.dataset?.composerId;
+    newComposerId !== preSelectedComposerId &&
+      setPreselectedComposerId(newComposerId);
 
-      const newComposerSection =
-        preselectPinboardHTMLElement?.dataset?.composerSection;
-      newComposerSection !== composerSection &&
-        setComposerSection(newComposerSection);
-    }
+    const newComposerSection =
+      preselectPinboardHTMLElement?.dataset?.composerSection;
+    newComposerSection !== composerSection &&
+      setComposerSection(newComposerSection);
   };
 
   const [
@@ -316,6 +311,7 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
           <GlobalStateProvider
             presetUnreadNotificationCount={presetUnreadNotificationCount}
             userEmail={userEmail}
+            openPinboardIdBasedOnQueryParam={openPinboardIdBasedOnQueryParam}
             preselectedComposerId={preSelectedComposerId}
             payloadToBeSent={payloadToBeSent}
             clearPayloadToBeSent={clearPayloadToBeSent}

--- a/client/src/push-notifications/serviceWorker.ts
+++ b/client/src/push-notifications/serviceWorker.ts
@@ -1,4 +1,7 @@
 import { ItemWithParsedPayload } from "../types/ItemWithParsedPayload";
+import { OPEN_PINBOARD_QUERY_PARAM } from "../../../shared/constants";
+
+const toolsDomain = self.location.hostname.replace("pinboard.", "");
 
 const showNotification = (
   item: ItemWithParsedPayload & {
@@ -73,8 +76,8 @@ self.addEventListener("notificationclick", (event: any) => {
 
   const item = event.notification.data;
 
-  // TODO make pinboard actually use these (a bit like we have for PRESELECT_PINBOARD_QUERY_PARAM)
-  const openToItemQueryParam = `pinboardId=${item.pinboardId}&pinboardItemId=${item.id}`;
+  // TODO add `&pinboardItemId=${item.id}` make pinboard actually scroll to that item
+  const openToItemQueryParam = `${OPEN_PINBOARD_QUERY_PARAM}=${item.pinboardId}`;
 
   event.waitUntil(
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -96,7 +99,10 @@ self.addEventListener("notificationclick", (event: any) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           self.clients.openWindow(
-            `https://media.gutools.co.uk/search?${openToItemQueryParam}`
+            `https://media.${toolsDomain}/search?${openToItemQueryParam}`.replace(
+              ".code.",
+              ".test."
+            )
           );
         } else if (
           event.action === "composer" ||
@@ -106,8 +112,8 @@ self.addEventListener("notificationclick", (event: any) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           self.clients.openWindow(
-            //TODO somehow find out the composer ID (perhaps workflow has a nice redirect service from pinboard ID i.e. workflow stub ID)
-            `https://composer.gutools.co.uk?${openToItemQueryParam}`
+            //FIXME somehow find out the composer ID (perhaps workflow has a nice redirect service from pinboard ID i.e. workflow stub ID)
+            `https://composer.${toolsDomain}?${openToItemQueryParam}`
           );
         }
       })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -10,3 +10,6 @@ export const MAX_PINBOARDS_TO_DISPLAY = 25;
 export const NOTIFICATIONS_LAMBDA_BASENAME = "pinboard-notifications-lambda";
 export const getNotificationsLambdaFunctionName = (stage: Stage) =>
   `${NOTIFICATIONS_LAMBDA_BASENAME}-${stage}`;
+
+export const OPEN_PINBOARD_QUERY_PARAM = "pinboardId";
+export const EXPAND_PINBOARD_QUERY_PARAM = "expandPinboard";


### PR DESCRIPTION
Previously notification clicks would always open PROD grid/composer AND the opening by query param was not implemented (now fixed/simplified in conjunction with https://github.com/guardian/workflow-frontend/pull/375).