### PR TITLE
'seen by' tweaks

### DIFF
--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -43,6 +43,7 @@ export const AvatarRoundel = ({
         width: ${size}px;
         height: ${size}px;
         border-radius: 50%;
+        border: 1px solid ${neutral[93]};
         background-color: ${composer.primary[300]};
         color: ${neutral[100]};
         display: flex;

--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -52,7 +52,7 @@ export const AvatarRoundel = ({
         justify-content: center;
         align-items: center;
         ${size < 20 // arbitrary breakpoint
-          ? agateSans.xxsmall()
+          ? `${agateSans.xxsmall()} font-size: 10px;`
           : agateSans.small()}
       `}
     >


### PR DESCRIPTION
Noticed when there were multiple 'seen bys' by people without avatars, the overlap looked horrible...
| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/19289579/191470567-1505d4fb-708a-4ec8-b8a2-97c796da972d.png) | ![image](https://user-images.githubusercontent.com/19289579/191470753-17632f7d-ff3a-4fa8-bb80-9594220e062c.png) | 

Now the text size is smaller, and a thin border which makes it easier to read.