### PR TITLE
fix unread flag not disappearing when last item seen in a different tab

### DIFF
--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -3,27 +3,16 @@ import { palette, space } from "@guardian/source-foundations";
 import React from "react";
 import { scrollbarsCss } from "./styling";
 import type { Item } from "../../shared/graphql/graphql";
-import type { PendingItem } from "./types/PendingItem";
 import { PayloadDisplay } from "./payloadDisplay";
 import { buildPayloadAndType, PayloadAndType } from "./types/PayloadAndType";
 import * as Sentry from "@sentry/react";
 
 interface AssetView {
-  initialItems: (Item | PendingItem)[];
-  successfulSends: PendingItem[];
-  subscriptionItems: Item[];
+  items: Item[];
 }
 
-export const AssetView: React.FC<AssetView> = ({
-  initialItems,
-  successfulSends,
-  subscriptionItems,
-}) => {
-  const payloadsMap: PayloadAndType[] = [
-    ...initialItems,
-    ...successfulSends,
-    ...subscriptionItems,
-  ]
+export const AssetView: React.FC<AssetView> = ({ items }) => {
+  const payloadsMap: PayloadAndType[] = items
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
     .reduce<PayloadAndType[]>((accumulator, item) => {
       if (!item.payload) {


### PR DESCRIPTION
Not entirely sure when this regression crept in, but was caused by the fact `ScrollableItems` component is unmounted when the pinboard is not 'selected' and because that's where we were building the itemMap (combination of initial items, sent items and items received on the subscription - for each pinboard) from which we set & unset the unread flag - it obviously wasn't clearing the unread flag when it was viewed in the other tab (despite actually having received the 'seen by' on the relevant subscription.

This fixes things by moving the itemMap logic and unread behaviour up to the parent `Pinboard` component, which remains mounted indefinitely.