### PR TITLE
ensure scrollableArea stays scrolled to bottom (if applicable) when images load slowly

### DIFF
--- a/client/src/grid/gridDynamicSearchDisplay.tsx
+++ b/client/src/grid/gridDynamicSearchDisplay.tsx
@@ -5,7 +5,7 @@ import {
   GridSearchSummary,
 } from "../../../shared/graphql/graphql";
 import { gqlGetGridSearchSummary } from "../../gql";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 import { useGlobalStateContext } from "../globalState";
 import { css } from "@emotion/react";
 import { space } from "@guardian/source-foundations";
@@ -14,7 +14,9 @@ import { FormattedDateTime } from "../formattedDateTime";
 import { GridBadge } from "./gridBadges";
 import { SvgReload } from "@guardian/source-react-components";
 
-type GridDynamicSearchDisplayProps = Pick<DynamicGridPayload, "payload">;
+type GridDynamicSearchDisplayProps = Pick<DynamicGridPayload, "payload"> & {
+  scrollToBottomIfApplicable: undefined | (() => void);
+};
 
 const formatChip = (chip: GridBadgeData) => {
   if (chip.text.match(/^[+-]/i)) {
@@ -26,6 +28,7 @@ const formatChip = (chip: GridBadgeData) => {
 
 export const GridDynamicSearchDisplay = ({
   payload,
+  scrollToBottomIfApplicable,
 }: GridDynamicSearchDisplayProps) => {
   const [
     gridSearchSummaryLastChecked,
@@ -71,6 +74,8 @@ export const GridDynamicSearchDisplay = ({
 
   const maybeQueryBreakdown = maybeGridSearchSummary?.queryBreakdown;
 
+  useLayoutEffect(() => scrollToBottomIfApplicable?.(), [maybeQueryBreakdown]);
+
   return (
     <React.Fragment>
       <div
@@ -91,6 +96,7 @@ export const GridDynamicSearchDisplay = ({
               height: "100%",
             }}
             draggable={false}
+            onLoad={scrollToBottomIfApplicable}
           />
         ))}
       </div>

--- a/client/src/grid/gridStaticImageDisplay.tsx
+++ b/client/src/grid/gridStaticImageDisplay.tsx
@@ -5,11 +5,14 @@ import CropIcon from "../../icons/crop.svg";
 import PictureIcon from "../../icons/picture.svg";
 import { palette } from "@guardian/source-foundations";
 
-type GridStaticImageDisplayProps = StaticGridPayload;
+type GridStaticImageDisplayProps = StaticGridPayload & {
+  scrollToBottomIfApplicable: undefined | (() => void);
+};
 
 export const GridStaticImageDisplay = ({
   type,
   payload,
+  scrollToBottomIfApplicable,
 }: GridStaticImageDisplayProps) => (
   <React.Fragment>
     <img
@@ -20,6 +23,7 @@ export const GridStaticImageDisplay = ({
         height: 100%;
       `}
       draggable={false}
+      onLoad={scrollToBottomIfApplicable}
       // TODO: hover for larger thumbnail
     />
 

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -116,6 +116,7 @@ interface ItemDisplayProps {
   userEmail: string;
   seenBy: LastItemSeenByUser[] | undefined;
   maybePreviousItem: Item | PendingItem | undefined;
+  scrollToBottomIfApplicable: () => void;
 }
 
 export const ItemDisplay = ({
@@ -124,6 +125,7 @@ export const ItemDisplay = ({
   userEmail,
   seenBy,
   maybePreviousItem,
+  scrollToBottomIfApplicable,
 }: ItemDisplayProps) => {
   const user = userLookup?.[item.userEmail];
   const payloadAndType = maybeConstructPayloadAndType(item.type, item.payload);
@@ -195,7 +197,11 @@ export const ItemDisplay = ({
         </div>
         <div>{formattedMessage}</div>
         {payloadAndType && (
-          <PayloadDisplay payloadAndType={payloadAndType} tab="chat" />
+          <PayloadDisplay
+            payloadAndType={payloadAndType}
+            tab="chat"
+            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
+          />
         )}
       </div>
       {seenBy && <SeenBy seenBy={seenBy} userLookup={userLookup} />}

--- a/client/src/payloadDisplay.tsx
+++ b/client/src/payloadDisplay.tsx
@@ -13,12 +13,14 @@ interface PayloadDisplayProps {
   payloadAndType: PayloadAndType;
   clearPayloadToBeSent?: () => void;
   tab?: Tab;
+  scrollToBottomIfApplicable?: () => void;
 }
 
 export const PayloadDisplay = ({
   payloadAndType,
   clearPayloadToBeSent,
   tab,
+  scrollToBottomIfApplicable,
 }: PayloadDisplayProps) => {
   const { payload } = payloadAndType;
   const sendTelemetryEvent = useContext(TelemetryContext);
@@ -72,11 +74,15 @@ export const PayloadDisplay = ({
           <GridStaticImageDisplay
             type={payloadAndType.type}
             payload={payloadAndType.payload}
+            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
           />
         )}
 
         {payloadAndType.type === "grid-search" && (
-          <GridDynamicSearchDisplay payload={payloadAndType.payload} />
+          <GridDynamicSearchDisplay
+            payload={payloadAndType.payload}
+            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
+          />
         )}
 
         {clearPayloadToBeSent && (

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -200,6 +200,9 @@ export const ScrollableItems = ({
 
   const onScrollThrottled = useThrottle(onScroll, 250);
 
+  const scrollToBottomIfApplicable = () =>
+    isScrolledToBottom && scrollToLastItem();
+
   return (
     <div
       ref={scrollableAreaRef}
@@ -220,6 +223,7 @@ export const ScrollableItems = ({
             userEmail={userEmail}
             seenBy={lastItemSeenByUsersForItemIDLookup[item.id]}
             maybePreviousItem={items[index - 1]}
+            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
           />
         ))}
       {hasUnread && (


### PR DESCRIPTION
_replaces https://github.com/guardian/pinboard/pull/165 (that was closed by GitHub in a rebasing snafu)_ 
<hr/>

Co-authored-by: @aracho1 
Co-authored-by: @phillipbarron  

Despite #154 and #171 there are occasions when it doesn't quite scroll to the bottom, this is cause by images and supporting information within `PayloadDisplay` loads asynchronously which take up more height. This PR passes through a function (to scroll to the bottom, only if we are already - see state added in #171) to the PayloadDisplay so that when the images load they can re-run that function, therefore neatly keeping us scrolled to the bottom if applicable (i.e. doesn't scroll to the bottom when we've explicitly scrolled up to read a previous message).
