### PR TITLE
new top-level `generate-appsync-auth-token` yarn script to generate an auth token for AppSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ This generation step is run for you as part of the `setup.sh`, `start.sh` and `c
 
 Note, `shared/graphql/schema.graphql` is also used in CDK to form part of the Cloudformation.
 
+### Testing queries/mutations from AppSync area of AWS Console (in the browser)
+
+Occasionally you may want to test the GraphQL queries/mutations directly from the AWS Console. You for which you will need an auth token, you can generate these by running `yarn generate-appsync-auth-token` in the root of the project and selecting CODE or PROD from the prompt.
+
 ## Running locally
 
 ### First-time set-up

--- a/bootstrapping-lambda/generateAppSyncAuthToken.ts
+++ b/bootstrapping-lambda/generateAppSyncAuthToken.ts
@@ -1,0 +1,29 @@
+import prompts from "prompts";
+import * as AWS from "aws-sdk";
+import { standardAwsConfig } from "../shared/awsIntegration";
+import { getYourEmail } from "../shared/local/yourEmail";
+
+(async () => {
+  const S3 = new AWS.S3(standardAwsConfig);
+
+  const { stage } = await prompts({
+    type: "select",
+    name: "stage",
+    message: "Stage?",
+    choices: [
+      { title: "CODE", value: "CODE", selected: true },
+      { title: "PROD", value: "PROD" },
+    ],
+  });
+
+  process.env.STAGE = stage;
+  process.env.GRAPHQL_ENDPOINT = "N/A";
+
+  const yourEmail = await getYourEmail();
+
+  // using dynamic import to allow us to override STAGE which is evaluated when the module is imported
+  const generateAppSyncConfig = (await import("./src/generateAppSyncConfig"))
+    .generateAppSyncConfig;
+
+  console.log((await generateAppSyncConfig(yourEmail, S3)).authToken);
+})();

--- a/notifications-lambda/run.ts
+++ b/notifications-lambda/run.ts
@@ -1,19 +1,14 @@
 import { handler, UserWithWebPushSubscription } from "./src";
 import { createDatabaseTunnel } from "../shared/database/local/databaseTunnel";
 import { getDatabaseConnection } from "../shared/database/databaseConnection";
-import { standardAwsConfig } from "../shared/awsIntegration";
-import AWS from "aws-sdk";
+import { getYourEmail } from "../shared/local/yourEmail";
 
 (async () => {
-  const userName = (
-    await new AWS.STS(standardAwsConfig).getCallerIdentity().promise()
-  ).UserId?.split(":")[1];
+  const yourEmail = await getYourEmail();
 
   await createDatabaseTunnel();
 
   const sql = await getDatabaseConnection();
-
-  const yourEmail = `${userName}@guardian.co.uk`;
 
   const yourUser = await sql`
       SELECT *

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "wsrun --parallel --fast-exit --prefix --report build ",
     "prepare": "husky install",
     "database-setup": "ts-node-dev shared/database/local/runDatabaseSetup.ts",
-    "database-migrate": "ts-node-dev shared/database/local/runDatabaseMigration.ts"
+    "database-migrate": "ts-node-dev shared/database/local/runDatabaseMigration.ts",
+    "generate-appsync-auth-token": "ts-node-dev bootstrapping-lambda/generateAppSyncAuthToken.ts"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "1.19.2",

--- a/shared/local/yourEmail.ts
+++ b/shared/local/yourEmail.ts
@@ -1,0 +1,10 @@
+import { standardAwsConfig } from "../awsIntegration";
+import AWS from "aws-sdk";
+
+export const getYourEmail = async () => {
+  const userName = (
+    await new AWS.STS(standardAwsConfig).getCallerIdentity().promise()
+  ).UserId?.split(":")[1];
+
+  return `${userName}@guardian.co.uk`;
+};


### PR DESCRIPTION
As per the changes to the README...
https://github.com/guardian/pinboard/blob/1545563ba453ee0b76fa62472f9ff93a9b0985c4/README.md?plain=1#L73-L75