### PR TITLE
PROD Load Testing Phase 1 of 4

### DIFF
--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -3,7 +3,7 @@ import * as lambda from "aws-lambda";
 import { default as express } from "express";
 import { loaderTemplate } from "./loaderTemplate";
 import { generateAppSyncConfig } from "./generateAppSyncConfig";
-import { standardAwsConfig } from "../../shared/awsIntegration";
+import { STAGE, standardAwsConfig } from "../../shared/awsIntegration";
 import { userHasPermission } from "./permissionCheck";
 import * as AWS from "aws-sdk";
 import fs from "fs";
@@ -57,6 +57,10 @@ server.get("/pinboard.loader.js", async (request, response) => {
   applyNoCaching(response); // absolutely no caching, as this JS will contain config/secrets to pass to the main
 
   applyJavascriptContentType(response);
+
+  if (STAGE === "PROD") {
+    return response.send("console.log('Pinboard PROD load testing');");
+  }
 
   const mainJsFilename: string | undefined = fs
     .readdirSync(clientDirectory)


### PR DESCRIPTION
https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing

Return basic `console.log` from `/pinboard.loader.js` in PROD only, to ensure `bootstrapping-lambda` can be called for every page load of composer/grid.
