### PR TITLE
use only 'Google People API' for `users-refresher-lambda`

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -555,7 +555,7 @@ export class PinBoardStack extends Stack {
       usersRefresherLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
-        memorySize: 128,
+        memorySize: 256,
         timeout: Duration.minutes(15),
         handler: "index.handler",
         environment: {

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -3269,7 +3269,7 @@ $util.toJson($ctx.result)",
           ],
         },
         "Handler": "index.handler",
-        "MemorySize": 128,
+        "MemorySize": 256,
         "Role": Object {
           "Fn::GetAtt": Array [
             "pinboardusersrefresherlambdaServiceRoleBF872882",

--- a/users-refresher-lambda/package.json
+++ b/users-refresher-lambda/package.json
@@ -16,7 +16,6 @@
     "ts-node-dev": "^1.0.0"
   },
   "dependencies": {
-    "@googleapis/admin": "^5.1.0",
     "@googleapis/people": "^1.0.2",
     "iniparser": "^1.0.5",
     "node-forge": "^1.3.0"

--- a/users-refresher-lambda/src/index.ts
+++ b/users-refresher-lambda/src/index.ts
@@ -1,5 +1,9 @@
-import { admin as googleAdminAPI, auth as googleAuth } from "@googleapis/admin";
-import { people as googlePeopleAPI } from "@googleapis/people";
+import {
+  people as googlePeopleAPI,
+  auth as googleAuth,
+  people_v1,
+} from "@googleapis/people";
+import Schema$Person = people_v1.Schema$Person;
 import * as AWS from "aws-sdk";
 import { standardAwsConfig } from "../../shared/awsIntegration";
 import {
@@ -9,22 +13,9 @@ import {
 import { p12ToPem } from "./p12ToPem";
 import { getPinboardPermissionOverrides } from "../../shared/permissions";
 import { getDatabaseConnection } from "../../shared/database/databaseConnection";
-const GUARDIAN_EMAIL_DOMAIN = "@guardian.co.uk";
+import { User } from "../../shared/graphql/graphql";
 
-interface BasicUser {
-  email: string;
-  isMentionable: boolean;
-}
-
-interface UserFromGoogle extends BasicUser {
-  resourceName: string;
-  firstName: string;
-  lastName: string;
-}
-
-const isUserFromGoogle = (
-  user: BasicUser | UserFromGoogle
-): user is UserFromGoogle => "resourceName" in user;
+const MAX_USERS_TO_LOOKUP_IN_ONE_RUN = 100;
 
 const S3 = new AWS.S3(standardAwsConfig);
 
@@ -33,60 +24,61 @@ export const handler = async ({
 }: {
   isProcessPermissionChangesOnly?: boolean;
 }) => {
-  const sql = await getDatabaseConnection();
-  const getStoredUsers = async (): Promise<BasicUser[]> =>
-    (await sql`SELECT "email", "isMentionable" FROM "User"`).map(
-      (user) => user as BasicUser
-    ) || [];
-
   const emailsOfUsersWithPinboardPermission = (
     await getPinboardPermissionOverrides(S3)
   )?.reduce<string[]>(
     (acc, { userId, active }) => (active ? [...acc, userId] : acc),
     []
   );
-
   if (!emailsOfUsersWithPinboardPermission) {
     throw Error("Could not get list of users with 'pinboard' permission.");
   }
 
-  const storedUsers = await getStoredUsers();
+  const sql = await getDatabaseConnection();
+  const storedUsers =
+    (await sql`SELECT "email", "isMentionable" FROM "User"`).map(
+      (user) => user
+    ) || [];
   const storedUsersEmails = storedUsers.map(({ email }) => email);
 
-  const basicUsersWherePinboardPermissionRemoved = storedUsers.reduce<
-    BasicUser[]
-  >(
-    (acc, { email, isMentionable }) =>
-      isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)
-        ? [
-            ...acc,
-            {
-              email,
-              isMentionable: false,
-            },
-          ]
-        : acc,
-    []
-  );
-  if (basicUsersWherePinboardPermissionRemoved.length > 0) {
-    console.log(
-      "DETECTED PINBOARD PERMISSIONS REMOVED FOR ",
-      basicUsersWherePinboardPermissionRemoved.map(({ email }) => email)
-    );
+  for (const { isMentionable, email } of storedUsers) {
+    if (isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)) {
+      console.log(
+        `Pinboard permission removed for for user ${email} so marking them as NOT mentionable.`
+      );
+
+      await sql`
+          UPDATE "User"
+          SET "isMentionable"=${isMentionable}
+          WHERE "email"=${email}
+      `.catch((error) =>
+        console.error(
+          `Error marking user ${email} as not mentionable...\n`,
+          error
+        )
+      );
+    }
   }
 
-  const emailsToLookup = emailsOfUsersWithPinboardPermission.filter(
+  const allEmailsToLookup = emailsOfUsersWithPinboardPermission.filter(
     (email) =>
       !isProcessPermissionChangesOnly || !storedUsersEmails.includes(email)
   );
+  const emailsToLookup = allEmailsToLookup.slice(
+    0,
+    MAX_USERS_TO_LOOKUP_IN_ONE_RUN
+  );
+
+  if (allEmailsToLookup.length > emailsToLookup.length) {
+    console.log(
+      `WARNING: There are ${allEmailsToLookup.length} users to lookup/process, which is too many for one run. Limiting to ${emailsToLookup.length}.`
+    );
+  }
 
   if (!isProcessPermissionChangesOnly) {
     console.log("FULL RUN");
   } else if (emailsToLookup.length > 0) {
     console.log("DETECTED PINBOARD PERMISSIONS ADDED FOR ", emailsToLookup);
-  } else if (basicUsersWherePinboardPermissionRemoved.length === 0) {
-    console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
-    return;
   }
 
   const pandaConfig = await getPandaConfig<{
@@ -104,144 +96,76 @@ export const handler = async ({
     ).Body?.toString("base64")
   );
 
-  const auth = new googleAuth.JWT({
-    key: serviceAccountPrivateKey,
-    scopes: [
-      "https://www.googleapis.com/auth/directory.readonly",
-      "https://www.googleapis.com/auth/admin.directory.user.readonly",
-      "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
-    ],
-    email: pandaConfig.googleServiceAccountId,
-    subject: pandaConfig.google2faUser,
-  });
-
-  const directoryService = googleAdminAPI({
-    version: "directory_v1",
-    auth,
-  });
-
   const peopleService = googlePeopleAPI({
     version: "v1",
-    auth,
+    auth: new googleAuth.JWT({
+      key: serviceAccountPrivateKey,
+      scopes: ["https://www.googleapis.com/auth/directory.readonly"],
+      email: pandaConfig.googleServiceAccountId,
+      subject: pandaConfig.google2faUser,
+    }),
   });
 
-  const usersWithPinboardPermission: Array<
-    BasicUser | UserFromGoogle
-  > = await Promise.all(
-    emailsToLookup.map(async (emailFromPermission) => {
-      const userResult = await directoryService.users
-        .get({
-          userKey: emailFromPermission,
+  for (const emailToLookup of emailsToLookup) {
+    try {
+      const namePartsOfEmail = emailToLookup.split("@")?.[0]?.split(".");
+
+      const user: Omit<User, "__typename"> = await peopleService.people
+        .searchDirectoryPeople({
+          query: emailToLookup,
+          readMask: "names,photos",
+          sources: [
+            "DIRECTORY_SOURCE_TYPE_DOMAIN_CONTACT",
+            "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE",
+          ],
         })
-        .catch((_) => _.response);
-
-      if (userResult.status === 404) {
-        return {
-          email: emailFromPermission,
-          isMentionable: false,
-        };
-      }
-      if (!userResult.data) {
-        throw Error("Invalid response from Google Directory API");
-      }
-      const { id, ...user } = userResult.data;
-      const email = user.primaryEmail?.endsWith(GUARDIAN_EMAIL_DOMAIN)
-        ? user.primaryEmail
-        : user.emails.find((_: { address: string }) =>
-            _.address.endsWith(GUARDIAN_EMAIL_DOMAIN)
-          )?.address;
-      return {
-        resourceName: `people/${id}`,
-        email,
-        firstName: user.name!.givenName!,
-        lastName: user.name!.familyName!,
-        isMentionable: true,
-      };
-    })
-  );
-
-  interface PhotoUrlLookup {
-    [resourceName: string]: string;
-  }
-  const buildPhotoUrlLookup = async (
-    resourceNames: string[]
-  ): Promise<PhotoUrlLookup> => {
-    if (resourceNames.length === 0) {
-      return {};
-    }
-    const hasMoreThan50Remaining = resourceNames.length > 50;
-    const usersToRequestInThisBatch = hasMoreThan50Remaining
-      ? resourceNames.slice(0, 50)
-      : resourceNames;
-
-    const thisBatchLookup = (
-      await peopleService.people.getBatchGet({
-        personFields: "photos",
-        resourceNames: usersToRequestInThisBatch,
-      })
-    ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
-      const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
-      return requestedResourceName && maybePhotoUrl
-        ? {
-            ...acc,
-            [requestedResourceName]: maybePhotoUrl,
+        .then((response) => {
+          const people: Schema$Person[] = response?.data?.people || [];
+          if (people.length === 1) {
+            const person: Schema$Person = people[0];
+            return {
+              email: emailToLookup,
+              isMentionable: true,
+              firstName:
+                person.names?.[0].givenName || //FIXME names not coming through
+                namePartsOfEmail?.[0] ||
+                emailToLookup,
+              lastName:
+                person.names?.[0].familyName ||
+                namePartsOfEmail?.[1] ||
+                emailToLookup,
+              avatarUrl: person.photos?.[0].url || null,
+            };
           }
-        : acc;
-    }, {} as PhotoUrlLookup);
+          if (people.length === 0) {
+            return {
+              email: emailToLookup,
+              isMentionable: false,
+              firstName: namePartsOfEmail?.[0] || emailToLookup,
+              lastName: namePartsOfEmail?.[1] || emailToLookup,
+              avatarUrl: null,
+            };
+          }
+          throw Error(`More than one user found for email ${emailToLookup}`);
+        });
 
-    if (!thisBatchLookup) {
-      throw Error();
-    }
+      console.log(
+        `Upserting details for user ${user.email} (isMentionable: ${user.isMentionable})`
+      );
 
-    return hasMoreThan50Remaining
-      ? {
-          ...thisBatchLookup,
-          ...(await buildPhotoUrlLookup(
-            resourceNames.slice(50, resourceNames.length)
-          )),
-        }
-      : thisBatchLookup;
-  };
-  const photoUrlLookup = await buildPhotoUrlLookup(
-    usersWithPinboardPermission
-      .filter(isUserFromGoogle)
-      .map(({ resourceName }) => resourceName)
-  );
-
-  const usersToUpsert: Array<BasicUser | UserFromGoogle> = [
-    ...usersWithPinboardPermission,
-    ...basicUsersWherePinboardPermissionRemoved,
-  ];
-
-  for (const user of usersToUpsert) {
-    console.log(`Upserting details for user ${user.email}`);
-
-    const handleError = (error: Error) => {
-      console.error(`Error upserting user ${user.email}\n`, error);
-      console.error(user);
-    };
-
-    if (isUserFromGoogle(user)) {
-      const { resourceName, ...userToUpsert } = user;
-      const maybeAvatarUrl = photoUrlLookup[resourceName];
       await sql`
-          INSERT INTO "User" ${sql(
-            maybeAvatarUrl
-              ? { ...userToUpsert, avatarUrl: maybeAvatarUrl }
-              : userToUpsert
-          )}
-          ON CONFLICT ("email") DO UPDATE SET
-            "firstName"=${user.firstName},
-            "lastName"=${user.lastName},
-            "isMentionable"=${user.isMentionable},
-            "avatarUrl"=${maybeAvatarUrl || null}
-      `.catch(handleError);
-    } else {
-      await sql`
-          UPDATE "User" 
-          SET "isMentionable"=${user.isMentionable}
-          WHERE "email"=${user.email} 
-      `.catch(handleError);
+        INSERT INTO "User" ${sql(user)}
+        ON CONFLICT ("email") DO UPDATE SET
+        "firstName"=${user.firstName},
+        "lastName"=${user.lastName},
+        "isMentionable"=${user.isMentionable},
+        "avatarUrl"=${user.avatarUrl}
+    `.catch((error) => {
+        console.error(`Error upserting user ${user.email}\n`, error);
+        console.error(user);
+      });
+    } catch (error) {
+      console.error(`Failed to lookup user ${emailToLookup}...\n`, error);
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,13 +1253,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@googleapis/admin@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@googleapis/admin/-/admin-5.1.0.tgz#c376c6fa00bae954cddc8dc394cda1f6c7106ce2"
-  integrity sha512-QzFwuRIAiwjP+9o+oNqOUEBelMnCK1CvgXhbPgpzcgFqMGja9o7nOB81TTnS1sgjahIyDhGmGoPvjz7oDN/lOQ==
-  dependencies:
-    googleapis-common "^5.0.1"
-
 "@googleapis/people@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@googleapis/people/-/people-1.0.2.tgz#82ebe2a4bc63b3a2b2c8f4e6229b3dfd94c7812b"


### PR DESCRIPTION
**_Creating this PR for visibility, but will close it immediately as it doesn't work..._**

When experimenting with https://github.com/guardian/permissions/pull/158 (which turned pinboard permission ON for everyone in `CODE`) `users-refresher-lambda` quickly attempted to ingest 1000s of new users, hitting Google's APIs hard and causing some rate limiting, which had a knock-on impact on panda login in PROD briefly (because we currently use the same service account, will be addressed in a separate PR soon).

When attempting to limit the number of users looked-up/processed in a single run of `users-refresher-lambda` (as a tactical measure to guard against the above), I got a bit carried away and ended up doing a big refactor.

Only at the last minute discovering that the People API doesn't return 'names' for anyone without a Google+ account (see https://stackoverflow.com/questions/50766097/method-people-get-does-not-return-names). I had not noticed this as I had been testing with my own user (in the API explorer, which uses your own login and does return private information for yourself 🤦 ).

There are lots of nice improvements in this PR though, which I'll use as inspiration when working on group mentions very soon (where we'll very likely use `users-refresher-lambda` to process 'group membership').