### PR TITLE
TACTICAL limit `users-refresher-lambda` to only lookup/process 50 users in one go (to avoid Google rate limiting)

### DIFF
--- a/users-refresher-lambda/src/index.ts
+++ b/users-refresher-lambda/src/index.ts
@@ -35,229 +35,236 @@ export const handler = async ({
   isProcessPermissionChangesOnly?: boolean;
 }) => {
   const sql = await getDatabaseConnection();
-  const getStoredUsers = async (): Promise<BasicUser[]> =>
-    (await sql`SELECT "email", "isMentionable" FROM "User"`).map(
-      (user) => user as BasicUser
-    ) || [];
+  try {
+    const getStoredUsers = async (): Promise<BasicUser[]> =>
+      (
+        await sql`SELECT "email", "isMentionable"
+                 FROM "User"`
+      ).map((user) => user as BasicUser) || [];
 
-  const emailsOfUsersWithPinboardPermission = (
-    await getPinboardPermissionOverrides(S3)
-  )?.reduce<string[]>(
-    (acc, { userId, active }) => (active ? [...acc, userId] : acc),
-    []
-  );
-
-  if (!emailsOfUsersWithPinboardPermission) {
-    throw Error("Could not get list of users with 'pinboard' permission.");
-  }
-
-  const storedUsers = await getStoredUsers();
-  const storedUsersEmails = storedUsers.map(({ email }) => email);
-
-  const basicUsersWherePinboardPermissionRemoved = storedUsers.reduce<
-    BasicUser[]
-  >(
-    (acc, { email, isMentionable }) =>
-      isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)
-        ? [
-            ...acc,
-            {
-              email,
-              isMentionable: false,
-            },
-          ]
-        : acc,
-    []
-  );
-  if (basicUsersWherePinboardPermissionRemoved.length > 0) {
-    console.log(
-      "DETECTED PINBOARD PERMISSIONS REMOVED FOR ",
-      basicUsersWherePinboardPermissionRemoved.map(({ email }) => email)
+    const emailsOfUsersWithPinboardPermission = (
+      await getPinboardPermissionOverrides(S3)
+    )?.reduce<string[]>(
+      (acc, { userId, active }) => (active ? [...acc, userId] : acc),
+      []
     );
-  }
 
-  const allEmailsToLookup = isProcessPermissionChangesOnly
-    ? emailsOfUsersWithPinboardPermission.filter(
-        (email) => !storedUsersEmails.includes(email)
-      )
-    : emailsOfUsersWithPinboardPermission;
-
-  const emailsToLookup = allEmailsToLookup.slice(
-    0,
-    MAX_USERS_TO_LOOKUP_IN_ONE_RUN
-  );
-
-  if (allEmailsToLookup.length > emailsToLookup.length) {
-    console.log(
-      `WARNING: there are ${allEmailsToLookup.length} emails to lookup/process which is too many for one run. Only processing ${MAX_USERS_TO_LOOKUP_IN_ONE_RUN} in this run.`
-    );
-  }
-
-  if (!isProcessPermissionChangesOnly) {
-    console.log("FULL RUN");
-  } else if (emailsToLookup.length > 0) {
-    console.log("DETECTED PINBOARD PERMISSIONS ADDED FOR ", emailsToLookup);
-  } else if (basicUsersWherePinboardPermissionRemoved.length === 0) {
-    console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
-    return;
-  }
-
-  const pandaConfig = await getPandaConfig<{
-    googleServiceAccountId: string;
-    googleServiceAccountCert: string;
-    google2faUser: string;
-  }>(S3);
-
-  const serviceAccountPrivateKey = p12ToPem(
-    (
-      await S3.getObject({
-        Bucket: pandaSettingsBucketName,
-        Key: pandaConfig.googleServiceAccountCert,
-      }).promise()
-    ).Body?.toString("base64")
-  );
-
-  const auth = new googleAuth.JWT({
-    key: serviceAccountPrivateKey,
-    scopes: [
-      "https://www.googleapis.com/auth/directory.readonly",
-      "https://www.googleapis.com/auth/admin.directory.user.readonly",
-      "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
-    ],
-    email: pandaConfig.googleServiceAccountId,
-    subject: pandaConfig.google2faUser,
-  });
-
-  const directoryService = googleAdminAPI({
-    version: "directory_v1",
-    auth,
-  });
-
-  const peopleService = googlePeopleAPI({
-    version: "v1",
-    auth,
-  });
-
-  // noinspection TypeScriptValidateJSTypes
-  const usersWithPinboardPermission: Array<
-    BasicUser | UserFromGoogle
-  > = await Promise.all(
-    emailsToLookup.map(async (emailFromPermission: string) => {
-      const userResult = await directoryService.users
-        .get({
-          userKey: emailFromPermission,
-        })
-        .catch((_) => _.response);
-
-      const namePartOfEmail = emailFromPermission.split("@")?.[0];
-      const namePartsFromEmail = namePartOfEmail?.split(".");
-      const firstNameFallback = namePartsFromEmail[0] || namePartOfEmail;
-      const lastNameFallback = namePartsFromEmail[1] || namePartOfEmail;
-
-      if (userResult.status === 404) {
-        return {
-          email: emailFromPermission,
-          firstName: firstNameFallback,
-          lastName: lastNameFallback,
-          isMentionable: false,
-        };
-      }
-      if (!userResult.data) {
-        throw Error("Invalid response from Google Directory API");
-      }
-      const { id, ...user } = userResult.data;
-      return {
-        resourceName: `people/${id}`,
-        email: emailFromPermission,
-        firstName: user.name?.givenName || firstNameFallback,
-        lastName: user.name?.familyName || lastNameFallback,
-        isMentionable: true,
-      };
-    })
-  );
-
-  interface PhotoUrlLookup {
-    [resourceName: string]: string;
-  }
-  const buildPhotoUrlLookup = async (
-    resourceNames: string[]
-  ): Promise<PhotoUrlLookup> => {
-    if (resourceNames.length === 0) {
-      return {};
-    }
-    const hasMoreThan50Remaining = resourceNames.length > 50;
-    const usersToRequestInThisBatch = hasMoreThan50Remaining
-      ? resourceNames.slice(0, 50)
-      : resourceNames;
-
-    const thisBatchLookup = (
-      await peopleService.people.getBatchGet({
-        personFields: "photos",
-        resourceNames: usersToRequestInThisBatch,
-      })
-    ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
-      const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
-      return requestedResourceName && maybePhotoUrl
-        ? {
-            ...acc,
-            [requestedResourceName]: maybePhotoUrl,
-          }
-        : acc;
-    }, {} as PhotoUrlLookup);
-
-    if (!thisBatchLookup) {
-      throw Error();
+    if (!emailsOfUsersWithPinboardPermission) {
+      throw Error("Could not get list of users with 'pinboard' permission.");
     }
 
-    return hasMoreThan50Remaining
-      ? {
-          ...thisBatchLookup,
-          ...(await buildPhotoUrlLookup(
-            resourceNames.slice(50, resourceNames.length)
-          )),
+    const storedUsers = await getStoredUsers();
+    const storedUsersEmails = storedUsers.map(({ email }) => email);
+
+    const basicUsersWherePinboardPermissionRemoved = storedUsers.reduce<
+      BasicUser[]
+    >(
+      (acc, { email, isMentionable }) =>
+        isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)
+          ? [
+              ...acc,
+              {
+                email,
+                isMentionable: false,
+              },
+            ]
+          : acc,
+      []
+    );
+    if (basicUsersWherePinboardPermissionRemoved.length > 0) {
+      console.log(
+        "DETECTED PINBOARD PERMISSIONS REMOVED FOR ",
+        basicUsersWherePinboardPermissionRemoved.map(({ email }) => email)
+      );
+    }
+
+    const allEmailsToLookup = isProcessPermissionChangesOnly
+      ? emailsOfUsersWithPinboardPermission.filter(
+          (email) => !storedUsersEmails.includes(email)
+        )
+      : emailsOfUsersWithPinboardPermission;
+
+    const emailsToLookup = allEmailsToLookup.slice(
+      0,
+      MAX_USERS_TO_LOOKUP_IN_ONE_RUN
+    );
+
+    if (allEmailsToLookup.length > emailsToLookup.length) {
+      console.log(
+        `WARNING: there are ${allEmailsToLookup.length} emails to lookup/process which is too many for one run. Only processing ${MAX_USERS_TO_LOOKUP_IN_ONE_RUN} in this run.`
+      );
+    }
+
+    if (!isProcessPermissionChangesOnly) {
+      console.log("FULL RUN");
+    } else if (emailsToLookup.length > 0) {
+      console.log("DETECTED PINBOARD PERMISSIONS ADDED FOR ", emailsToLookup);
+    } else if (basicUsersWherePinboardPermissionRemoved.length === 0) {
+      console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
+      return;
+    }
+
+    const pandaConfig = await getPandaConfig<{
+      googleServiceAccountId: string;
+      googleServiceAccountCert: string;
+      google2faUser: string;
+    }>(S3);
+
+    const serviceAccountPrivateKey = p12ToPem(
+      (
+        await S3.getObject({
+          Bucket: pandaSettingsBucketName,
+          Key: pandaConfig.googleServiceAccountCert,
+        }).promise()
+      ).Body?.toString("base64")
+    );
+
+    const auth = new googleAuth.JWT({
+      key: serviceAccountPrivateKey,
+      scopes: [
+        "https://www.googleapis.com/auth/directory.readonly",
+        "https://www.googleapis.com/auth/admin.directory.user.readonly",
+        "https://www.googleapis.com/auth/admin.directory.group.member.readonly",
+      ],
+      email: pandaConfig.googleServiceAccountId,
+      subject: pandaConfig.google2faUser,
+    });
+
+    const directoryService = googleAdminAPI({
+      version: "directory_v1",
+      auth,
+    });
+
+    const peopleService = googlePeopleAPI({
+      version: "v1",
+      auth,
+    });
+
+    // noinspection TypeScriptValidateJSTypes
+    const usersWithPinboardPermission: Array<
+      BasicUser | UserFromGoogle
+    > = await Promise.all(
+      emailsToLookup.map(async (emailFromPermission: string) => {
+        const userResult = await directoryService.users
+          .get({
+            userKey: emailFromPermission,
+          })
+          .catch((_) => _.response);
+
+        const namePartOfEmail = emailFromPermission.split("@")?.[0];
+        const namePartsFromEmail = namePartOfEmail?.split(".");
+        const firstNameFallback = namePartsFromEmail[0] || namePartOfEmail;
+        const lastNameFallback = namePartsFromEmail[1] || namePartOfEmail;
+
+        if (userResult.status === 404) {
+          return {
+            email: emailFromPermission,
+            firstName: firstNameFallback,
+            lastName: lastNameFallback,
+            isMentionable: false,
+          };
         }
-      : thisBatchLookup;
-  };
-  const photoUrlLookup = await buildPhotoUrlLookup(
-    usersWithPinboardPermission
-      .filter(isUserFromGoogle)
-      .map(({ resourceName }) => resourceName)
-  );
+        if (!userResult.data) {
+          throw Error("Invalid response from Google Directory API");
+        }
+        const { id, ...user } = userResult.data;
+        return {
+          resourceName: `people/${id}`,
+          email: emailFromPermission,
+          firstName: user.name?.givenName || firstNameFallback,
+          lastName: user.name?.familyName || lastNameFallback,
+          isMentionable: true,
+        };
+      })
+    );
 
-  const usersToUpsert: Array<BasicUser | UserFromGoogle> = [
-    ...usersWithPinboardPermission,
-    ...basicUsersWherePinboardPermissionRemoved,
-  ];
+    interface PhotoUrlLookup {
+      [resourceName: string]: string;
+    }
 
-  for (const user of usersToUpsert) {
-    console.log(`Upserting details for user ${user.email}`);
+    const buildPhotoUrlLookup = async (
+      resourceNames: string[]
+    ): Promise<PhotoUrlLookup> => {
+      if (resourceNames.length === 0) {
+        return {};
+      }
+      const hasMoreThan50Remaining = resourceNames.length > 50;
+      const usersToRequestInThisBatch = hasMoreThan50Remaining
+        ? resourceNames.slice(0, 50)
+        : resourceNames;
 
-    const handleError = (error: Error) => {
-      console.error(`Error upserting user ${user.email}\n`, error);
-      console.error(user);
+      const thisBatchLookup = (
+        await peopleService.people.getBatchGet({
+          personFields: "photos",
+          resourceNames: usersToRequestInThisBatch,
+        })
+      ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
+        const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
+        return requestedResourceName && maybePhotoUrl
+          ? {
+              ...acc,
+              [requestedResourceName]: maybePhotoUrl,
+            }
+          : acc;
+      }, {} as PhotoUrlLookup);
+
+      if (!thisBatchLookup) {
+        throw Error();
+      }
+
+      return hasMoreThan50Remaining
+        ? {
+            ...thisBatchLookup,
+            ...(await buildPhotoUrlLookup(
+              resourceNames.slice(50, resourceNames.length)
+            )),
+          }
+        : thisBatchLookup;
     };
+    const photoUrlLookup = await buildPhotoUrlLookup(
+      usersWithPinboardPermission
+        .filter(isUserFromGoogle)
+        .map(({ resourceName }) => resourceName)
+    );
 
-    if (isUserFromGoogle(user) || "firstName" in user) {
-      const { resourceName, ...userToUpsert } = user;
-      const maybeAvatarUrl = photoUrlLookup[resourceName];
-      await sql`
-          INSERT INTO "User" ${sql(
-            maybeAvatarUrl
-              ? { ...userToUpsert, avatarUrl: maybeAvatarUrl }
-              : userToUpsert
-          )}
-          ON CONFLICT ("email") DO UPDATE SET
+    const usersToUpsert: Array<BasicUser | UserFromGoogle> = [
+      ...usersWithPinboardPermission,
+      ...basicUsersWherePinboardPermissionRemoved,
+    ];
+
+    for (const user of usersToUpsert) {
+      console.log(`Upserting details for user ${user.email}`);
+
+      const handleError = (error: Error) => {
+        console.error(`Error upserting user ${user.email}\n`, error);
+        console.error(user);
+      };
+
+      if (isUserFromGoogle(user) || "firstName" in user) {
+        const { resourceName, ...userToUpsert } = user;
+        const maybeAvatarUrl = photoUrlLookup[resourceName];
+        await sql`
+            INSERT INTO "User" ${sql(
+              maybeAvatarUrl
+                ? { ...userToUpsert, avatarUrl: maybeAvatarUrl }
+                : userToUpsert
+            )}
+            ON CONFLICT ("email")
+            DO UPDATE SET
             "firstName"=${user.firstName},
             "lastName"=${user.lastName},
             "isMentionable"=${user.isMentionable},
             "avatarUrl"=${maybeAvatarUrl || null}
-      `.catch(handleError);
-    } else {
-      await sql`
-          UPDATE "User" 
-          SET "isMentionable"=${user.isMentionable}
-          WHERE "email"=${user.email} 
-      `.catch(handleError);
+        `.catch(handleError);
+      } else {
+        await sql`
+            UPDATE "User"
+            SET "isMentionable"=${user.isMentionable}
+            WHERE "email" = ${user.email}
+        `.catch(handleError);
+      }
     }
+  } finally {
+    await sql.end();
   }
 };


### PR DESCRIPTION
As mentioned in https://github.com/guardian/pinboard/pull/183; when experimenting with https://github.com/guardian/permissions/pull/158 (which turned pinboard permission ON for everyone in CODE) `users-refresher-lambda` quickly attempted to ingest 1000s of new users, hitting Google's APIs hard and causing some rate limiting, which had a knock-on impact on panda login in PROD briefly (because we currently use the same service account, [will be addressed in a separate PR soon](https://trello.com/c/ICvAsa1w/855-dont-re-use-panda-google-account-for-pinboard-users-refresher-lambda)).

This TACTICAL PR limits that to 50 in a single run (including the nightly 'full run' which kinda renders it a bit useless when we have more than 50 users), but we will soon be making significant changes to `users-refresher-lambda` when we implement group mentions (https://trello.com/c/IfRJvfZV/202-pinboard-mentions-phase-3-group-mentions).

PLUS:
- simplifies what email address we use, it now just uses the original email (from the permissions list) we use to lookup the details, rather than trying to derive the email back from the response
- ensures users with permission who are missing from Google directory still get added to DB (by inferring the `firstName` and `lastName` from the email address)
- ensures DB connection always closed regardless of success/failure outcome


