### PR TITLE
load user info async in client, rather than loading all users up-front

### DIFF
--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -1068,7 +1068,6 @@ type Query {
   listItems(pinboardId: String!): [Item]
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
-  listUsers: [User]
   searchMentionableUsers(prefix: String!): [User]
   getUsers(emails: [String!]!): [User]
 
@@ -1221,7 +1220,7 @@ input LastItemSeenByUserInput {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1242,7 +1241,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1263,7 +1262,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1284,7 +1283,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1305,7 +1304,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1326,7 +1325,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1347,7 +1346,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1368,7 +1367,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1389,28 +1388,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
-$util.toJson($ctx.result)",
-        "TypeName": "Query",
-      },
-      "Type": "AWS::AppSync::Resolver",
-    },
-    "pinboardappsyncapidatabasebridgelambdadsQuerylistUsersResolver5D9F6D38": Object {
-      "DependsOn": Array [
-        "pinboardappsyncapidatabasebridgelambdads970CB9A7",
-        "pinboardappsyncapiSchema868D9F5B",
-      ],
-      "Properties": Object {
-        "ApiId": Object {
-          "Fn::GetAtt": Array [
-            "pinboardappsyncapi9D519400",
-            "ApiId",
-          ],
-        },
-        "DataSourceName": "database_bridge_lambda_ds",
-        "FieldName": "listUsers",
-        "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1431,7 +1409,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1556,7 +1534,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1681,7 +1659,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1702,7 +1680,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1723,7 +1701,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -1069,6 +1069,8 @@ type Query {
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
   listUsers: [User]
+  searchMentionableUsers(prefix: String!): [User]
+  getUsers(emails: [String!]!): [User]
 
   listPinboards(searchText: String): [WorkflowStub]
   getPinboardsByIds(ids: [String!]!): [WorkflowStub]
@@ -1172,7 +1174,8 @@ input CreateItemInput {
 input LastItemSeenByUserInput {
   pinboardId: String!
   itemID: String!
-}",
+}
+",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
     },
@@ -1218,7 +1221,7 @@ input LastItemSeenByUserInput {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1239,7 +1242,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1260,7 +1263,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1281,7 +1284,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1302,7 +1305,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1323,7 +1326,28 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+$util.toJson($ctx.result)",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "pinboardappsyncapidatabasebridgelambdadsQuerygetUsersResolver1122D64B": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapidatabasebridgelambdads970CB9A7",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "database_bridge_lambda_ds",
+        "FieldName": "getUsers",
+        "Kind": "UNIT",
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1344,7 +1368,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1365,7 +1389,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1386,7 +1410,28 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
+$util.toJson($ctx.result)",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "pinboardappsyncapidatabasebridgelambdadsQuerysearchMentionableUsersResolver81EB32B3": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapidatabasebridgelambdads970CB9A7",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "database_bridge_lambda_ds",
+        "FieldName": "searchMentionableUsers",
+        "Kind": "UNIT",
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1511,7 +1556,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1636,7 +1681,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1657,7 +1702,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1678,7 +1723,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : ec341970b323acbc4146f5852acf0929
+        "ResponseMappingTemplate": "## schema checksum : 55ca5d219594a4f6d4cbe7ba04048923
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -80,15 +80,6 @@ const myUserReturnFields = `${userReturnFields}
   manuallyOpenedPinboardIds
 `;
 
-export const gqlGetAllUsers = gql`
-    query MyQuery {
-        listUsers {
-            ${userReturnFields}
-            isMentionable
-        }
-    }
-`;
-
 export const gqlSearchMentionableUsers = (prefix: string) => gql`
     query MyQuery {
         searchMentionableUsers(prefix: "${prefix}") {

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -89,6 +89,24 @@ export const gqlGetAllUsers = gql`
     }
 `;
 
+export const gqlSearchMentionableUsers = (prefix: string) => gql`
+    query MyQuery {
+        searchMentionableUsers(prefix: "${prefix}") {
+            ${userReturnFields}
+            isMentionable
+        }
+    }
+`;
+
+export const gqlGetUsers = gql`
+    query MyQuery($emails: [String!]!) {
+        getUsers(emails: $emails) {
+            ${userReturnFields}
+            isMentionable
+        }
+    }
+`;
+
 export const gqlGetMyUser = gql`
 query MyQuery {
   getMyUser {

--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -86,6 +86,7 @@ export const CreateItemInputBox = ({
     apolloClient
       .query({
         query: gqlSearchMentionableUsers(token),
+        context: { debounceKey: "user-search", debounceTimeout: 250 },
       })
       .then((queryResult) => queryResult.data.searchMentionableUsers);
 

--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -123,7 +123,12 @@ export const CreateItemInputBox = ({
           "@": {
             dataProvider: mentionsDataProvider,
             component: UserSuggestion,
-            output: userToMentionHandle, // TODO: ensure backspacing onto the lastName brings the prompt back up (the space is problematic)
+            output: (user) => ({
+              key: user.email,
+              text: userToMentionHandle(user),
+              caretPosition: "next",
+            }),
+            allowWhitespace: true,
           },
         }}
         minChar={0}

--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -12,9 +12,26 @@ import { scrollbarsCss } from "./styling";
 import { composer } from "../colours";
 import { useApolloClient } from "@apollo/client";
 import { gqlSearchMentionableUsers } from "../gql";
+import { SvgSpinner } from "@guardian/source-react-components";
 interface WithEntity<E> {
   entity: E;
 }
+
+const LoadingUsers = () => (
+  <div
+    css={css`
+      display: flex;
+      align-items: center;
+      gap: ${space["2"]}px;
+      background: ${palette.neutral["100"]};
+      padding: ${space["2"]}px;
+      font-family: ${agateSans.small({ lineHeight: "tight" })};
+    `}
+  >
+    <SvgSpinner size="xsmall" />
+    <span>loading</span>
+  </div>
+);
 
 const UserSuggestion = ({ entity }: WithEntity<User>) => (
   <div
@@ -110,7 +127,7 @@ export const CreateItemInputBox = ({
           },
         }}
         minChar={0}
-        loadingComponent={() => <span>Loading</span>}
+        loadingComponent={LoadingUsers}
         placeholder="enter message here..."
         value={message}
         onChange={(event) => {

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -7,7 +7,7 @@ import {
   useSubscription,
 } from "@apollo/client";
 import React, { useCallback, useContext, useEffect, useState } from "react";
-import { Item, MyUser, User } from "../../shared/graphql/graphql";
+import { Item, MyUser } from "../../shared/graphql/graphql";
 import {
   gqlAddManuallyOpenedPinboardIds,
   gqlGetPinboardByComposerId,
@@ -24,12 +24,14 @@ import { ChatTab, Tab } from "./types/Tab";
 import { ControlPosition } from "react-draggable";
 import { bottom, top, floatySize, right } from "./styling";
 import { EXPAND_PINBOARD_QUERY_PARAM } from "../../shared/constants";
+import { UserLookup } from "./types/UserLookup";
 
 const LOCAL_STORAGE_KEY_EXPLICIT_POSITION = "pinboard-explicit-position";
 
 interface GlobalStateContextShape {
   userEmail: string;
-  userLookup: { [email: string]: User } | undefined;
+  userLookup: UserLookup;
+  addEmailsToLookup: (emails: string[]) => void;
 
   activeTab: Tab;
   setActiveTab: (tab: Tab) => void;
@@ -100,7 +102,8 @@ interface GlobalStateProviderProps {
   clearPayloadToBeSent: () => void;
   isExpanded: boolean;
   setIsExpanded: (_: boolean) => void;
-  userLookup: { [email: string]: User } | undefined;
+  userLookup: UserLookup;
+  addEmailsToLookup: (emails: string[]) => void;
   hasWebPushSubscription: boolean | null | undefined;
   manuallyOpenedPinboardIds: string[];
   setManuallyOpenedPinboardIds: (newMyUser: MyUser) => void;
@@ -118,6 +121,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   isExpanded,
   setIsExpanded,
   userLookup,
+  addEmailsToLookup,
   hasWebPushSubscription,
   manuallyOpenedPinboardIds,
   setManuallyOpenedPinboardIds,
@@ -472,6 +476,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const contextValue: GlobalStateContextShape = {
     userEmail,
     userLookup,
+    addEmailsToLookup,
 
     activeTab,
     setActiveTab,

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -16,6 +16,7 @@ import {
 } from "./types/PayloadAndType";
 import { FormattedDateTime } from "./formattedDateTime";
 import * as Sentry from "@sentry/react";
+import { UserLookup } from "./types/UserLookup";
 
 const userMentioned = (unread: boolean | undefined) => css`
   color: white;
@@ -112,7 +113,7 @@ const maybeConstructPayloadAndType = (
 
 interface ItemDisplayProps {
   item: Item | PendingItem;
-  userLookup: { [email: string]: User } | undefined;
+  userLookup: UserLookup;
   userEmail: string;
   seenBy: LastItemSeenByUser[] | undefined;
   maybePreviousItem: Item | PendingItem | undefined;

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -273,7 +273,6 @@ export const Pinboard: React.FC<PinboardProps> = ({
           onSuccessfulSend={onSuccessfulSend}
           payloadToBeSent={payloadToBeSent}
           clearPayloadToBeSent={clearPayloadToBeSent}
-          allUsers={userLookup && Object.values(userLookup)}
           onError={(error) => setError(pinboardId, error)}
           userEmail={userEmail}
           pinboardId={pinboardId}

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -1,4 +1,4 @@
-import { Item, LastItemSeenByUser, User } from "../../shared/graphql/graphql";
+import { Item, LastItemSeenByUser } from "../../shared/graphql/graphql";
 import React, {
   useCallback,
   useContext,
@@ -19,6 +19,7 @@ import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { useGlobalStateContext } from "./globalState";
 import { useThrottle } from "./util";
 import { PendingItem } from "./types/PendingItem";
+import { UserLookup } from "./types/UserLookup";
 
 interface ScrollableItemsProps {
   items: Item[];
@@ -27,7 +28,7 @@ interface ScrollableItemsProps {
   maybeLastItem: Item | undefined;
   hasUnread: boolean | undefined;
   isExpanded: boolean;
-  userLookup: { [email: string]: User } | undefined;
+  userLookup: UserLookup;
   userEmail: string;
   pinboardId: string;
   lastItemSeenByUserLookup: LastItemSeenByUserLookup;

--- a/client/src/seenBy.tsx
+++ b/client/src/seenBy.tsx
@@ -2,11 +2,12 @@ import { css } from "@emotion/react";
 import { palette } from "@guardian/source-foundations";
 import { SvgPlus } from "@guardian/source-react-components";
 import React, { useContext } from "react";
-import { LastItemSeenByUser, User } from "../../shared/graphql/graphql";
+import { LastItemSeenByUser } from "../../shared/graphql/graphql";
 import { agateSans } from "../fontNormaliser";
 import { AvatarRoundel } from "./avatarRoundel";
 import { TickContext } from "./formattedDateTime";
 import { formatDateTime } from "./util";
+import { UserLookup } from "./types/UserLookup";
 
 const maxSeenByIcons = 2;
 const roundelHeightPx = 15;
@@ -14,7 +15,7 @@ const roundelOverlapPct = 25;
 
 interface SeenByProps {
   seenBy: LastItemSeenByUser[];
-  userLookup: { [email: string]: User } | undefined;
+  userLookup: UserLookup;
 }
 
 export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -17,7 +17,6 @@ import { SvgSpinner } from "@guardian/source-react-components";
 interface SendMessageAreaProps {
   payloadToBeSent: PayloadAndType | null;
   clearPayloadToBeSent: () => void;
-  allUsers: User[] | undefined;
   onSuccessfulSend: (item: PendingItem) => void;
   onError: (error: ApolloError) => void;
   userEmail: string;
@@ -28,7 +27,6 @@ interface SendMessageAreaProps {
 export const SendMessageArea = ({
   payloadToBeSent,
   clearPayloadToBeSent,
-  allUsers,
   onSuccessfulSend,
   onError,
   pinboardId,
@@ -98,7 +96,6 @@ export const SendMessageArea = ({
         message={message}
         setMessage={setMessage}
         sendItem={sendItem}
-        allUsers={allUsers}
         addUnverifiedMention={addUnverifiedMention}
         panelElement={panelElement}
         isSending={isItemSending}

--- a/client/src/types/UserLookup.ts
+++ b/client/src/types/UserLookup.ts
@@ -1,0 +1,3 @@
+import { User } from "../../../shared/graphql/graphql";
+
+export type UserLookup = { [email: string]: User };

--- a/database-bridge-lambda/src/index.ts
+++ b/database-bridge-lambda/src/index.ts
@@ -9,7 +9,6 @@ import {
   addManuallyOpenedPinboardIds,
   getMyUser,
   getUsers,
-  listUsers,
   removeManuallyOpenedPinboardIds,
   searchMentionableUsers,
   setWebPushSubscriptionForUser,
@@ -32,8 +31,6 @@ const run = (
       return seenItem(sql, args, userEmail);
     case "listLastItemSeenByUsers":
       return listLastItemSeenByUsers(sql, args);
-    case "listUsers":
-      return listUsers(sql);
     case "searchMentionableUsers":
       return searchMentionableUsers(sql, args);
     case "getUsers":

--- a/database-bridge-lambda/src/index.ts
+++ b/database-bridge-lambda/src/index.ts
@@ -8,8 +8,10 @@ import { listLastItemSeenByUsers, seenItem } from "./sql/LastItemSeenByUser";
 import {
   addManuallyOpenedPinboardIds,
   getMyUser,
+  getUsers,
   listUsers,
   removeManuallyOpenedPinboardIds,
+  searchMentionableUsers,
   setWebPushSubscriptionForUser,
 } from "./sql/User";
 import { getDatabaseConnection } from "../../shared/database/databaseConnection";
@@ -32,6 +34,10 @@ const run = (
       return listLastItemSeenByUsers(sql, args);
     case "listUsers":
       return listUsers(sql);
+    case "searchMentionableUsers":
+      return searchMentionableUsers(sql, args);
+    case "getUsers":
+      return getUsers(sql, args);
     case "getMyUser":
       return getMyUser(sql, userEmail);
     case "setWebPushSubscriptionForUser":

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -18,7 +18,7 @@ export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
       "firstName" ILIKE ${args.prefix + "%"}
         OR "lastName" ILIKE ${args.prefix + "%"}
     )
-    ORDER BY "firstName"
+    ORDER BY "webPushSubscription" IS NOT NULL DESC, "manuallyOpenedPinboardIds" IS NOT NULL DESC, "firstName" 
     LIMIT 5
 `;
 

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -1,11 +1,31 @@
 import { Sql } from "../../../shared/database/types";
 
+const fragmentUserWithoutPushSubscriptionSecrets = (sql: Sql) =>
+  sql`"email", "firstName", "lastName", "avatarUrl", "isMentionable"`;
+
 export const listUsers = (sql: Sql) => sql`
-    SELECT "email", "firstName", "lastName", "avatarUrl", "isMentionable"
+    SELECT ${fragmentUserWithoutPushSubscriptionSecrets(sql)}
     FROM "User"
     ORDER BY "isMentionable" DESC, "manuallyOpenedPinboardIds" IS NOT NULL DESC, "webPushSubscription" IS NOT NULL DESC
     LIMIT 25
 `;
+
+export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
+  sql`
+    SELECT ${fragmentUserWithoutPushSubscriptionSecrets(sql)}
+    FROM "User"
+    WHERE "isMentionable" = true AND (
+      "firstName" ILIKE ${args.prefix + "%"}
+        OR "lastName" ILIKE ${args.prefix + "%"}
+    )
+`;
+
+export const getUsers = (sql: Sql, args: { emails: string[] }) =>
+  sql`
+      SELECT ${fragmentUserWithoutPushSubscriptionSecrets(sql)}
+      FROM "User"
+      WHERE "email" IN ${sql(args.emails)}
+  `;
 
 const fragmentMyUserWithoutPushSubscriptionSecrets = (sql: Sql) =>
   sql`"email", "firstName", "lastName", "avatarUrl", "manuallyOpenedPinboardIds", "webPushSubscription" IS NOT NULL AS "hasWebPushSubscription"`;

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -18,6 +18,7 @@ export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
       "firstName" ILIKE ${args.prefix + "%"}
         OR "lastName" ILIKE ${args.prefix + "%"}
     )
+    ORDER BY "firstName"
     LIMIT 5
 `;
 

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -18,6 +18,7 @@ export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
       "firstName" ILIKE ${args.prefix + "%"}
         OR "lastName" ILIKE ${args.prefix + "%"}
     )
+    LIMIT 5
 `;
 
 export const getUsers = (sql: Sql, args: { emails: string[] }) =>

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -17,6 +17,7 @@ export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
     WHERE "isMentionable" = true AND (
       "firstName" ILIKE ${args.prefix + "%"}
         OR "lastName" ILIKE ${args.prefix + "%"}
+        OR CONCAT("firstName", ' ', "lastName") ILIKE ${args.prefix + "%"}
     )
     ORDER BY "webPushSubscription" IS NOT NULL DESC, "manuallyOpenedPinboardIds" IS NOT NULL DESC, "firstName" 
     LIMIT 5

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -3,6 +3,8 @@ import { Sql } from "../../../shared/database/types";
 export const listUsers = (sql: Sql) => sql`
     SELECT "email", "firstName", "lastName", "avatarUrl", "isMentionable"
     FROM "User"
+    ORDER BY "isMentionable" DESC, "manuallyOpenedPinboardIds" IS NOT NULL DESC, "webPushSubscription" IS NOT NULL DESC
+    LIMIT 25
 `;
 
 const fragmentMyUserWithoutPushSubscriptionSecrets = (sql: Sql) =>

--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -3,13 +3,6 @@ import { Sql } from "../../../shared/database/types";
 const fragmentUserWithoutPushSubscriptionSecrets = (sql: Sql) =>
   sql`"email", "firstName", "lastName", "avatarUrl", "isMentionable"`;
 
-export const listUsers = (sql: Sql) => sql`
-    SELECT ${fragmentUserWithoutPushSubscriptionSecrets(sql)}
-    FROM "User"
-    ORDER BY "isMentionable" DESC, "manuallyOpenedPinboardIds" IS NOT NULL DESC, "webPushSubscription" IS NOT NULL DESC
-    LIMIT 25
-`;
-
 export const searchMentionableUsers = (sql: Sql, args: { prefix: string }) =>
   sql`
     SELECT ${fragmentUserWithoutPushSubscriptionSecrets(sql)}

--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -6,7 +6,6 @@ export const QUERIES = {
     "listItems",
     "listLastItemSeenByUsers",
     "getMyUser",
-    "listUsers",
     "searchMentionableUsers",
     "getUsers",
   ] as const,

--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -7,6 +7,8 @@ export const QUERIES = {
     "listLastItemSeenByUsers",
     "getMyUser",
     "listUsers",
+    "searchMentionableUsers",
+    "getUsers",
   ] as const,
   workflow: [
     "listPinboards",

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -9,6 +9,8 @@ type Query {
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
   listUsers: [User]
+  searchMentionableUsers(prefix: String!): [User]
+  getUsers(emails: [String!]!): [User]
 
   listPinboards(searchText: String): [WorkflowStub]
   getPinboardsByIds(ids: [String!]!): [WorkflowStub]

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -8,7 +8,6 @@ type Query {
   listItems(pinboardId: String!): [Item]
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
-  listUsers: [User]
   searchMentionableUsers(prefix: String!): [User]
   getUsers(emails: [String!]!): [User]
 


### PR DESCRIPTION
Co-authored-by: @phillipbarron 
Co-authored-by: @aracho1 

https://trello.com/c/KIlzwMGx/849-load-pinboard-user-info-asynchronously-on-client

As part of https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing we gave pinboard permission to everyone in `CODE` which once loaded into the DB (by `users-refresher-lambda` - rate limiting issues aside), we began experiencing slowness in composer (and probs. grid) as the client loads all users to build a lookup and populate the mentions autocomplete and there were now 1000s so things got slow.

This synchronous/up-front approach was arguably always temporary, but recent events mean it needs to be addressed now, and ahead of https://trello.com/c/IfRJvfZV/202-pinboard-mentions-phase-3-group-mentions.

### What's changed?

- add `searchMentionableUsers` and `getUsers` GraphQL queries with handlers in `database-bridge-lambda`
- use `searchMentionableUsers` to populate mentions autocomplete (rather than useLookup) on keypress (with debounce of 250ms to avoid unnecessary DB queries without making the UI too sluggish) - ordered by first name, but preferring users with `webPushSubscription` and/or some `manuallyOpenedPinboardIds` (i.e. people who've interacted with pinboard before)
- improved the 'loading' component for the mentions autocomplete (now we see it more as we wait for response from server)
![image](https://user-images.githubusercontent.com/19289579/193860557-bf3326cb-1801-45e4-950e-4af294c884cc.png)
- handle users with same first and last names in mentions autocomplete (by using email address as unique key)
- mentions autocomplete now also supports matching full names (i.e. with space) - which is useful now we have 1000s of users (with lots of Toms for example)
- When building the user lookup, replaced upfront call to `listUsers` with piecemeal calls to `getUsers` as and when we encounter user emails where we do not have `User` information in local state.