### PR TITLE
PROD Load Testing Phase 2 of 4

### DIFF
--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -58,10 +58,6 @@ server.get("/pinboard.loader.js", async (request, response) => {
 
   applyJavascriptContentType(response);
 
-  if (STAGE === "PROD") {
-    return response.send("console.log('Pinboard PROD load testing');");
-  }
-
   const mainJsFilename: string | undefined = fs
     .readdirSync(clientDirectory)
     .filter(
@@ -96,6 +92,12 @@ server.get("/pinboard.loader.js", async (request, response) => {
     response.send(`console.error('${message}')`);
   } else if (await userHasPermission(maybeAuthedUserEmail)) {
     const appSyncConfig = await generateAppSyncConfig(maybeAuthedUserEmail, S3);
+
+    if (STAGE === "PROD") {
+      return response.send(
+        "console.log('Pinboard PROD load testing (Phase 2)');"
+      );
+    }
 
     response.send(
       loaderTemplate(


### PR DESCRIPTION
_Following https://github.com/guardian/pinboard/pull/181_

https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing

`/pinboard.loader.js` does all its normal stuff, but instead of returning the output of `loaderTemplate` it returns basic `console.log` from `/pinboard.loader.js` in PROD only
