### PR TITLE
PROD Load Testing Phase 3 of 4

### DIFF
--- a/bootstrapping-lambda/src/loaderTemplate.ts
+++ b/bootstrapping-lambda/src/loaderTemplate.ts
@@ -1,5 +1,6 @@
 // TODO see if there is some nice library for syntax highlighting the string interpolation e.g. js`...`
 import { ClientConfig } from "../../shared/clientConfig";
+import { STAGE } from "../../shared/awsIntegration";
 
 export const loaderTemplate = (
   clientConfig: ClientConfig,
@@ -10,7 +11,11 @@ export const loaderTemplate = (
   if(typeof PinBoard === 'undefined') { // this avoids pinboard being added to the page more than once
     const script = document.createElement('script');
     script.onload = function () {
-      PinBoard.mount(${JSON.stringify(clientConfig)});
+        ${
+          STAGE === "PROD"
+            ? "console.log('Pinboard PROD load testing (Phase 3)');"
+            : `PinBoard.mount(${JSON.stringify(clientConfig)});`
+        }
     };
     script.src = 'https://${hostname}/${mainJsFilename}';
     document.head.appendChild(script);

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -92,13 +92,6 @@ server.get("/pinboard.loader.js", async (request, response) => {
     response.send(`console.error('${message}')`);
   } else if (await userHasPermission(maybeAuthedUserEmail)) {
     const appSyncConfig = await generateAppSyncConfig(maybeAuthedUserEmail, S3);
-
-    if (STAGE === "PROD") {
-      return response.send(
-        "console.log('Pinboard PROD load testing (Phase 2)');"
-      );
-    }
-
     response.send(
       loaderTemplate(
         {


### PR DESCRIPTION
_Following #181 and #186 _

https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing

`/pinboard.loader.js` does everything as normal, but `loaderTemplate` doesn't call `Pinboard.mount` in PROD (instead `console.log`s accordingly)
