### PR TITLE
Exclude .js and .jsx files in tsconfig to ensure eslint does not run out of memory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "exclude": ["**/*.js*"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 


### PR DESCRIPTION
… when attempting to process generated js (e.g. in dist directories)

Co-authored-by: @phillipbarron 
Co-authored-by: @twrichards 
