### PR TITLE
PROD Load Testing Phase 4 of 4

### DIFF
--- a/bootstrapping-lambda/src/loaderTemplate.ts
+++ b/bootstrapping-lambda/src/loaderTemplate.ts
@@ -13,9 +13,10 @@ export const loaderTemplate = (
     script.onload = function () {
         ${
           STAGE === "PROD"
-            ? "console.log('Pinboard PROD load testing (Phase 3)');"
-            : `PinBoard.mount(${JSON.stringify(clientConfig)});`
+            ? "console.log('Pinboard PROD load testing (Phase 4)');"
+            : ""
         }
+        PinBoard.mount(${JSON.stringify(clientConfig)});
     };
     script.src = 'https://${hostname}/${mainJsFilename}';
     document.head.appendChild(script);

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -3,7 +3,7 @@ import * as lambda from "aws-lambda";
 import { default as express } from "express";
 import { loaderTemplate } from "./loaderTemplate";
 import { generateAppSyncConfig } from "./generateAppSyncConfig";
-import { STAGE, standardAwsConfig } from "../../shared/awsIntegration";
+import { standardAwsConfig } from "../../shared/awsIntegration";
 import { userHasPermission } from "./permissionCheck";
 import * as AWS from "aws-sdk";
 import fs from "fs";

--- a/client/src/addToPinboardButton.tsx
+++ b/client/src/addToPinboardButton.tsx
@@ -16,6 +16,7 @@ interface AddToPinboardButtonProps {
   dataAttributes: DOMStringMap;
   setPayloadToBeSent: (payload: PayloadAndType | null) => void;
   expand: () => void;
+  isLoadTesting: boolean;
 }
 
 const AddToPinboardButton = (props: AddToPinboardButtonProps) => {
@@ -43,6 +44,7 @@ const AddToPinboardButton = (props: AddToPinboardButtonProps) => {
     <root.div
       css={css`
         ${textSans.small()}
+        display: ${props.isLoadTesting ? "none" : "block"};
       `}
     >
       <button
@@ -88,6 +90,7 @@ interface ButtonPortalProps {
   node: HTMLElement;
   setPayloadToBeSent: (payload: PayloadAndType | null) => void;
   expand: () => void;
+  isLoadTesting: boolean;
 }
 
 export const ButtonPortal = ({

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -44,9 +44,14 @@ const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
 interface PinBoardAppProps {
   apolloClient: ApolloClient<Record<string, unknown>>;
   userEmail: string;
+  isLoadTesting: boolean;
 }
 
-export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
+export const PinBoardApp = ({
+  apolloClient,
+  userEmail,
+  isLoadTesting,
+}: PinBoardAppProps) => {
   const [payloadToBeSent, setPayloadToBeSent] = useState<PayloadAndType | null>(
     null
   );
@@ -306,6 +311,9 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
       <ApolloProvider client={apolloClient}>
         <HiddenIFrameForServiceWorker iFrameRef={serviceWorkerIFrameRef} />
         <root.div
+          css={{
+            display: isLoadTesting ? "none" : "block",
+          }}
           onDragOver={(event) =>
             isGridDragEvent(event) && event.preventDefault()
           }
@@ -363,6 +371,7 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
             node={node}
             setPayloadToBeSent={setPayloadToBeSent}
             expand={expandFloaty}
+            isLoadTesting={isLoadTesting}
           />
         ))}
       </ApolloProvider>

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -164,7 +164,11 @@ export function mount({
 
   render(
     <TelemetryContext.Provider value={sendTelemetryEvent}>
-      <PinBoardApp apolloClient={apolloClient} userEmail={userEmail} />
+      <PinBoardApp
+        apolloClient={apolloClient}
+        userEmail={userEmail}
+        isLoadTesting={stage === "PROD"}
+      />
     </TelemetryContext.Provider>,
     element
   );


### PR DESCRIPTION
_Following #181, #186 and #188 _

https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing

`/pinboard.loader.js` does everything as normal, and Pinboard is mounted but hidden (via css `display: none`) in PROD (to ensure APIs etc. are hit with base level of load, but nobody actually sees anything pinboardy)