### PR TITLE
now PROD load testing is complete, revert the four load testing PRs

### DIFF
--- a/bootstrapping-lambda/src/loaderTemplate.ts
+++ b/bootstrapping-lambda/src/loaderTemplate.ts
@@ -1,6 +1,5 @@
 // TODO see if there is some nice library for syntax highlighting the string interpolation e.g. js`...`
 import { ClientConfig } from "../../shared/clientConfig";
-import { STAGE } from "../../shared/awsIntegration";
 
 export const loaderTemplate = (
   clientConfig: ClientConfig,
@@ -11,12 +10,7 @@ export const loaderTemplate = (
   if(typeof PinBoard === 'undefined') { // this avoids pinboard being added to the page more than once
     const script = document.createElement('script');
     script.onload = function () {
-        ${
-          STAGE === "PROD"
-            ? "console.log('Pinboard PROD load testing (Phase 4)');"
-            : ""
-        }
-        PinBoard.mount(${JSON.stringify(clientConfig)});
+      PinBoard.mount(${JSON.stringify(clientConfig)});
     };
     script.src = 'https://${hostname}/${mainJsFilename}';
     document.head.appendChild(script);

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -92,6 +92,7 @@ server.get("/pinboard.loader.js", async (request, response) => {
     response.send(`console.error('${message}')`);
   } else if (await userHasPermission(maybeAuthedUserEmail)) {
     const appSyncConfig = await generateAppSyncConfig(maybeAuthedUserEmail, S3);
+
     response.send(
       loaderTemplate(
         {

--- a/client/src/addToPinboardButton.tsx
+++ b/client/src/addToPinboardButton.tsx
@@ -16,7 +16,6 @@ interface AddToPinboardButtonProps {
   dataAttributes: DOMStringMap;
   setPayloadToBeSent: (payload: PayloadAndType | null) => void;
   expand: () => void;
-  isLoadTesting: boolean;
 }
 
 const AddToPinboardButton = (props: AddToPinboardButtonProps) => {
@@ -44,7 +43,6 @@ const AddToPinboardButton = (props: AddToPinboardButtonProps) => {
     <root.div
       css={css`
         ${textSans.small()}
-        display: ${props.isLoadTesting ? "none" : "block"};
       `}
     >
       <button
@@ -90,7 +88,6 @@ interface ButtonPortalProps {
   node: HTMLElement;
   setPayloadToBeSent: (payload: PayloadAndType | null) => void;
   expand: () => void;
-  isLoadTesting: boolean;
 }
 
 export const ButtonPortal = ({

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -44,14 +44,9 @@ const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
 interface PinBoardAppProps {
   apolloClient: ApolloClient<Record<string, unknown>>;
   userEmail: string;
-  isLoadTesting: boolean;
 }
 
-export const PinBoardApp = ({
-  apolloClient,
-  userEmail,
-  isLoadTesting,
-}: PinBoardAppProps) => {
+export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
   const [payloadToBeSent, setPayloadToBeSent] = useState<PayloadAndType | null>(
     null
   );
@@ -311,9 +306,6 @@ export const PinBoardApp = ({
       <ApolloProvider client={apolloClient}>
         <HiddenIFrameForServiceWorker iFrameRef={serviceWorkerIFrameRef} />
         <root.div
-          css={{
-            display: isLoadTesting ? "none" : "block",
-          }}
           onDragOver={(event) =>
             isGridDragEvent(event) && event.preventDefault()
           }
@@ -371,7 +363,6 @@ export const PinBoardApp = ({
             node={node}
             setPayloadToBeSent={setPayloadToBeSent}
             expand={expandFloaty}
-            isLoadTesting={isLoadTesting}
           />
         ))}
       </ApolloProvider>

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -164,11 +164,7 @@ export function mount({
 
   render(
     <TelemetryContext.Provider value={sendTelemetryEvent}>
-      <PinBoardApp
-        apolloClient={apolloClient}
-        userEmail={userEmail}
-        isLoadTesting={stage === "PROD"}
-      />
+      <PinBoardApp apolloClient={apolloClient} userEmail={userEmail} />
     </TelemetryContext.Provider>,
     element
   );


### PR DESCRIPTION
## MUST BE RELEASED AFTER https://github.com/guardian/permissions/pull/160 (and once `users-refresher-lambda` has processed the removals).

https://trello.com/c/gsH0VyYU/837-pinboard-prod-load-testing

### REVERTS
- https://github.com/guardian/pinboard/pull/181
- https://github.com/guardian/pinboard/pull/186
- https://github.com/guardian/pinboard/pull/188
- https://github.com/guardian/pinboard/pull/191