### PR TITLE
refactor `user-refresher-lambda` and begin tracking `googleID`s

### DIFF
--- a/shared/database/local/runDatabaseSetup.ts
+++ b/shared/database/local/runDatabaseSetup.ts
@@ -42,6 +42,8 @@ const runSetupSqlFile = (sql: Sql, fileName: string) =>
           .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
           .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
       ),
+    "add googleID column to User table": () =>
+      runSetupSqlFile(sql, "008-AddGoogleIDToUserTable.sql"),
   };
 
   const allSteps = async () => {

--- a/shared/database/local/setup/008-AddGoogleIdToUserTable.sql
+++ b/shared/database/local/setup/008-AddGoogleIdToUserTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "googleID" varchar(512);

--- a/users-refresher-lambda/package.json
+++ b/users-refresher-lambda/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/iniparser": "^0.0.29",
+    "@types/node-fetch": "2",
     "@types/node-forge": "^0.9.7",
     "aws-sdk": "^2.840.0",
     "ts-node-dev": "^1.0.0"
@@ -19,6 +20,7 @@
     "@googleapis/admin": "^5.1.0",
     "@googleapis/people": "^1.0.2",
     "iniparser": "^1.0.5",
+    "node-fetch": "2",
     "node-forge": "^1.3.0"
   }
 }

--- a/users-refresher-lambda/run.ts
+++ b/users-refresher-lambda/run.ts
@@ -1,7 +1,20 @@
 import { handler } from "./src";
 import { createDatabaseTunnel } from "../shared/database/local/databaseTunnel";
+import prompts from "prompts";
 
 (async () => {
+  const { inputEvent } = await prompts({
+    type: "select",
+    name: "inputEvent",
+    message: "",
+    choices: [
+      { title: "FULL RUN", value: {}, selected: true },
+      {
+        title: "process permission changes only",
+        value: { isProcessPermissionChangesOnly: true },
+      },
+    ],
+  });
   await createDatabaseTunnel();
-  await handler({});
+  await handler(inputEvent);
 })();

--- a/users-refresher-lambda/src/google/buildPhotoUrlLookup.ts
+++ b/users-refresher-lambda/src/google/buildPhotoUrlLookup.ts
@@ -1,0 +1,50 @@
+import { people_v1 } from "@googleapis/people";
+
+interface PhotoUrlLookup {
+  [resourceName: string]: string;
+}
+export const buildPhotoUrlLookup = async (
+  peopleService: people_v1.People,
+  resourceNames: string[]
+): Promise<PhotoUrlLookup> => {
+  if (resourceNames.length === 0) {
+    return {};
+  }
+  const hasMoreThan50Remaining = resourceNames.length > 50;
+  const usersToRequestInThisBatch = hasMoreThan50Remaining
+    ? resourceNames.slice(0, 50)
+    : resourceNames;
+
+  console.log(
+    `Google People API call (for ${usersToRequestInThisBatch.length} users)`
+  );
+
+  const thisBatchLookup = (
+    await peopleService.people.getBatchGet({
+      personFields: "photos",
+      resourceNames: usersToRequestInThisBatch,
+    })
+  ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
+    const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
+    return requestedResourceName && maybePhotoUrl
+      ? {
+          ...acc,
+          [requestedResourceName]: maybePhotoUrl,
+        }
+      : acc;
+  }, {} as PhotoUrlLookup);
+
+  if (!thisBatchLookup) {
+    throw Error();
+  }
+
+  return hasMoreThan50Remaining
+    ? {
+        ...thisBatchLookup,
+        ...(await buildPhotoUrlLookup(
+          peopleService,
+          resourceNames.slice(50, resourceNames.length)
+        )),
+      }
+    : thisBatchLookup;
+};

--- a/users-refresher-lambda/src/google/buildUserLookupFromDatabase.ts
+++ b/users-refresher-lambda/src/google/buildUserLookupFromDatabase.ts
@@ -1,0 +1,10 @@
+import { Sql } from "../../../shared/database/types";
+import { User, UserLookup } from "../util";
+
+export const buildUserLookupFromDatabase = (sql: Sql): Promise<UserLookup> =>
+  sql`SELECT * FROM "User"`.then((users) =>
+    users.reduce(
+      (acc, userRow) => ({ ...acc, [userRow.email]: userRow as User }),
+      {} as UserLookup
+    )
+  );

--- a/users-refresher-lambda/src/google/buildUserLookupFromGoogle.ts
+++ b/users-refresher-lambda/src/google/buildUserLookupFromGoogle.ts
@@ -1,0 +1,62 @@
+import { admin_directory_v1 } from "@googleapis/admin";
+import { extractNamesWithFallback, User, UserLookup } from "../util";
+
+export const buildUserLookupFromGoogle = async (
+  directoryService: admin_directory_v1.Admin,
+  emailsToLookup: string[],
+  nextPageToken?: string
+): Promise<UserLookup> => {
+  console.log(`Google Admin Directory API call (users.list)`);
+
+  const page = await directoryService.users.list({
+    maxResults: 500,
+    pageToken: nextPageToken,
+    domain: "guardian.co.uk",
+    projection: "BASIC",
+  });
+
+  console.log(
+    `...processing paged response, containing ${page?.data?.users?.length} users`
+  );
+
+  const thisPagesLookup: UserLookup = (page.data?.users || []).reduce(
+    (acc, { id, emails, name }) => {
+      const maybeRelevantUserEmail =
+        emails &&
+        emailsToLookup.find(
+          (lookupEmail) =>
+            lookupEmail &&
+            emails.find(
+              ({ address }: { address: string }) =>
+                address === lookupEmail.toLowerCase()
+            )
+        );
+      if (!maybeRelevantUserEmail || !id) {
+        return acc;
+      }
+      const names = extractNamesWithFallback(maybeRelevantUserEmail, name);
+      const relevantUser: User = {
+        googleID: id,
+        email: maybeRelevantUserEmail,
+        ...names,
+        isMentionable: true,
+      };
+      return {
+        ...acc,
+        [maybeRelevantUserEmail]: relevantUser,
+      };
+    },
+    {} as UserLookup
+  );
+
+  return page.data?.nextPageToken
+    ? {
+        ...thisPagesLookup,
+        ...(await buildUserLookupFromGoogle(
+          directoryService,
+          emailsToLookup,
+          page.data?.nextPageToken
+        )),
+      }
+    : thisPagesLookup;
+};

--- a/users-refresher-lambda/src/google/isDefinitelyDifferentAvatar.ts
+++ b/users-refresher-lambda/src/google/isDefinitelyDifferentAvatar.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+
+/*
+ * The Google People API returns an unstable avatar URL (i.e. different every time)
+ * for a handful of users (long-serving staff members we think - i.e. old avatars).
+ * So this function downloads the avatars to compare the file content, so we can
+ * only update the DB when the avatar image has truly changed.
+ * */
+export const isDefinitelyDifferentAvatar = async (
+  userEmail: string,
+  databaseAvatarUrl: string | null | undefined,
+  apiAvatarUrl: string | null
+): Promise<boolean> => {
+  if (databaseAvatarUrl === apiAvatarUrl) {
+    return false;
+  }
+  if (!databaseAvatarUrl || !apiAvatarUrl) {
+    return true;
+  }
+  const [databaseAvatar, apiAvatar] = await Promise.all(
+    [databaseAvatarUrl, apiAvatarUrl].map((url) =>
+      fetch(url).then((res) => res.text())
+    )
+  );
+  if (databaseAvatar === apiAvatar) {
+    console.warn(
+      `Avatar for ${userEmail} has the same content, but the URLs are different - thanks Google!`
+    );
+  }
+  return databaseAvatar !== apiAvatar;
+};

--- a/users-refresher-lambda/src/index.ts
+++ b/users-refresher-lambda/src/index.ts
@@ -8,24 +8,11 @@ import {
 } from "../../shared/awsIntegration";
 import { getPinboardPermissionOverrides } from "../../shared/permissions";
 import { getDatabaseConnection } from "../../shared/database/databaseConnection";
-
-const MAX_USERS_TO_LOOKUP_IN_ONE_RUN = 1000;
-
-interface BasicUser {
-  email: string;
-  isMentionable: boolean;
-  googleID: string | null; // null denotes that the user is not in the Google directory (typically because they have left the organisation)
-}
-
-interface UserFromGoogle extends BasicUser {
-  resourceName: string;
-  firstName: string;
-  lastName: string;
-}
-
-const isUserFromGoogle = (
-  user: BasicUser | UserFromGoogle
-): user is UserFromGoogle => "resourceName" in user;
+import { buildPhotoUrlLookup } from "./google/buildPhotoUrlLookup";
+import { buildUserLookupFromGoogle } from "./google/buildUserLookupFromGoogle";
+import { extractNamesWithFallback, handleUpsertError } from "./util";
+import { buildUserLookupFromDatabase } from "./google/buildUserLookupFromDatabase";
+import { isDefinitelyDifferentAvatar } from "./google/isDefinitelyDifferentAvatar";
 
 const S3 = new AWS.S3(standardAwsConfig);
 
@@ -34,76 +21,62 @@ export const handler = async ({
 }: {
   isProcessPermissionChangesOnly?: boolean;
 }) => {
+  const emailsOfUsersWithPinboardPermission = (
+    await getPinboardPermissionOverrides(S3)
+  )?.reduce<string[]>(
+    (acc, { userId, active }) =>
+      active ? [...acc, userId.toLowerCase()] : acc,
+    []
+  );
+  if (!emailsOfUsersWithPinboardPermission) {
+    throw Error("Could not get list of users with 'pinboard' permission.");
+  }
+
   const sql = await getDatabaseConnection();
+
   try {
-    const getStoredUsers = async (): Promise<BasicUser[]> =>
-      (
-        await sql`SELECT "email", "isMentionable", "googleID"
-                 FROM "User"`
-      ).map((user) => user as BasicUser) || [];
+    const usersFromDatabaseLookup = await buildUserLookupFromDatabase(sql);
 
-    const emailsOfUsersWithPinboardPermission = (
-      await getPinboardPermissionOverrides(S3)
-    )?.reduce<string[]>(
-      (acc, { userId, active }) => (active ? [...acc, userId] : acc),
-      []
-    );
-
-    if (!emailsOfUsersWithPinboardPermission) {
-      throw Error("Could not get list of users with 'pinboard' permission.");
+    for (const user of Object.values(usersFromDatabaseLookup)) {
+      if (
+        user.isMentionable &&
+        !emailsOfUsersWithPinboardPermission.includes(user.email)
+      ) {
+        console.log(
+          `Permission removed for ${user.email}, so marking as not mentionable`
+        );
+        await sql`
+          UPDATE "User" 
+          SET "isMentionable" = false 
+          WHERE "email" = ${user.email}
+        `.catch(handleUpsertError(user));
+      }
     }
 
-    const storedUsers = await getStoredUsers();
-
-    const basicUsersWherePinboardPermissionRemoved = storedUsers.reduce<
-      BasicUser[]
-    >(
-      (acc, { email, isMentionable, googleID }) =>
-        isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)
-          ? [
-              ...acc,
-              {
+    if (
+      isProcessPermissionChangesOnly &&
+      emailsOfUsersWithPinboardPermission.every((email) => {
+        const maybeUserFromDatabase = usersFromDatabaseLookup[email];
+        const isStoredInCorrectState =
+          maybeUserFromDatabase &&
+          (maybeUserFromDatabase.isMentionable ||
+            !maybeUserFromDatabase.googleID);
+        if (!isStoredInCorrectState) {
+          maybeUserFromDatabase
+            ? console.log(
+                "Found user with permission, but user needs updating in DB",
                 email,
-                googleID,
-                isMentionable: false,
-              },
-            ]
-          : acc,
-      []
-    );
-    if (basicUsersWherePinboardPermissionRemoved.length > 0) {
-      console.log(
-        "DETECTED PINBOARD PERMISSIONS REMOVED FOR ",
-        basicUsersWherePinboardPermissionRemoved.map(({ email }) => email)
-      );
-    }
-
-    const allEmailsToLookup = isProcessPermissionChangesOnly
-      ? emailsOfUsersWithPinboardPermission.filter(
-          (email) =>
-            !storedUsers.find(
-              (storedUser) => storedUser.email === email && storedUser.googleID //TODO check this is the correct way round
-            )
-        )
-      : emailsOfUsersWithPinboardPermission;
-
-    const emailsToLookup = allEmailsToLookup.slice(
-      0,
-      MAX_USERS_TO_LOOKUP_IN_ONE_RUN
-    );
-
-    if (allEmailsToLookup.length > emailsToLookup.length) {
-      console.log(
-        `WARNING: there are ${allEmailsToLookup.length} emails to lookup/process which is too many for one run. Only processing ${MAX_USERS_TO_LOOKUP_IN_ONE_RUN} in this run.`
-      );
-    }
-
-    if (!isProcessPermissionChangesOnly) {
-      console.log("FULL RUN");
-    } else if (emailsToLookup.length > 0) {
-      console.log("DETECTED PINBOARD PERMISSIONS ADDED FOR ", emailsToLookup);
-    } else if (basicUsersWherePinboardPermissionRemoved.length === 0) {
-      console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
+                maybeUserFromDatabase
+              )
+            : console.log(
+                "Found user with permission, but user not in DB",
+                email
+              );
+        }
+        return isStoredInCorrectState;
+      })
+    ) {
+      console.log("NO PINBOARD PERMISSIONS CHANGED, exiting early");
       return;
     }
 
@@ -134,138 +107,85 @@ export const handler = async ({
       auth,
     });
 
-    // noinspection TypeScriptValidateJSTypes
-    const usersWithPinboardPermission: Array<
-      BasicUser | UserFromGoogle
-    > = await Promise.all(
-      emailsToLookup.map(async (emailFromPermission: string) => {
-        const userResult = await directoryService.users
-          .get({
-            userKey: emailFromPermission,
-          })
-          .catch((_) => _.response);
-
-        const namePartOfEmail = emailFromPermission.split("@")?.[0];
-        const namePartsFromEmail = namePartOfEmail?.split(".");
-        const firstNameFallback = namePartsFromEmail[0] || namePartOfEmail;
-        const lastNameFallback = namePartsFromEmail[1] || namePartOfEmail;
-
-        if (userResult.status === 404) {
-          return {
-            email: emailFromPermission,
-            firstName: firstNameFallback,
-            lastName: lastNameFallback,
-            isMentionable: false,
-            googleID: null,
-          };
-        }
-        if (userResult.data?.error?.message?.startsWith("Type not supported")) {
-          return {
-            email: emailFromPermission,
-            isMentionable: false,
-          };
-        }
-        if (!userResult.data || userResult.data.error) {
-          console.log(emailFromPermission, userResult.data?.error);
-          throw Error("Invalid response from Google Directory API");
-        }
-        const { id, ...user } = userResult.data;
-        return {
-          resourceName: `people/${id}`,
-          googleID: id,
-          email: emailFromPermission,
-          firstName: user.name?.givenName || firstNameFallback,
-          lastName: user.name?.familyName || lastNameFallback,
-          isMentionable: true,
-        };
-      })
+    const usersFromGoogleLookup = await buildUserLookupFromGoogle(
+      directoryService,
+      emailsOfUsersWithPinboardPermission
     );
 
-    interface PhotoUrlLookup {
-      [resourceName: string]: string;
-    }
-
-    const buildPhotoUrlLookup = async (
-      resourceNames: string[]
-    ): Promise<PhotoUrlLookup> => {
-      if (resourceNames.length === 0) {
-        return {};
-      }
-      const hasMoreThan50Remaining = resourceNames.length > 50;
-      const usersToRequestInThisBatch = hasMoreThan50Remaining
-        ? resourceNames.slice(0, 50)
-        : resourceNames;
-
-      const thisBatchLookup = (
-        await peopleService.people.getBatchGet({
-          personFields: "photos",
-          resourceNames: usersToRequestInThisBatch,
-        })
-      ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
-        const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
-        return requestedResourceName && maybePhotoUrl
-          ? {
-              ...acc,
-              [requestedResourceName]: maybePhotoUrl,
-            }
-          : acc;
-      }, {} as PhotoUrlLookup);
-
-      if (!thisBatchLookup) {
-        throw Error();
-      }
-
-      return hasMoreThan50Remaining
-        ? {
-            ...thisBatchLookup,
-            ...(await buildPhotoUrlLookup(
-              resourceNames.slice(50, resourceNames.length)
-            )),
-          }
-        : thisBatchLookup;
-    };
     const photoUrlLookup = await buildPhotoUrlLookup(
-      usersWithPinboardPermission
-        .filter(isUserFromGoogle)
-        .map(({ resourceName }) => resourceName)
+      peopleService,
+      Object.values(usersFromGoogleLookup).map(
+        ({ googleID }) => `people/${googleID}`
+      )
     );
 
-    const usersToUpsert: Array<BasicUser | UserFromGoogle> = [
-      ...usersWithPinboardPermission,
-      ...basicUsersWherePinboardPermissionRemoved,
-    ];
+    for (const email of emailsOfUsersWithPinboardPermission) {
+      const maybeUserFromGoogle = usersFromGoogleLookup[email];
+      const maybeUserFromDatabase = usersFromDatabaseLookup[email];
 
-    for (const user of usersToUpsert) {
-      console.log(`Upserting details for user ${user.email}`);
-
-      const handleError = (error: Error) => {
-        console.error(`Error upserting user ${user.email}\n`, error);
-        console.error(user);
-      };
-
-      if (isUserFromGoogle(user) || "firstName" in user) {
-        const { resourceName, ...userToUpsert } = user;
-        const maybeAvatarUrl = photoUrlLookup[resourceName];
+      if (maybeUserFromGoogle) {
+        const maybeAvatarUrl =
+          photoUrlLookup[`people/${maybeUserFromGoogle.googleID}`] || null;
+        if (!maybeUserFromDatabase) {
+          console.log(`Inserting details for user ${email}`);
+          const user = { ...maybeUserFromGoogle, avatarUrl: maybeAvatarUrl };
+          await sql`
+            INSERT INTO "User" ${sql(user)}
+          `.catch(handleUpsertError(user));
+        } else if (
+          maybeUserFromDatabase.isMentionable !==
+            maybeUserFromGoogle.isMentionable ||
+          maybeUserFromDatabase.firstName !== maybeUserFromGoogle.firstName ||
+          maybeUserFromDatabase.lastName !== maybeUserFromGoogle.lastName ||
+          maybeUserFromDatabase.googleID !== maybeUserFromGoogle.googleID ||
+          (await isDefinitelyDifferentAvatar(
+            email,
+            maybeUserFromDatabase.avatarUrl,
+            maybeAvatarUrl
+          ))
+        ) {
+          console.log(`Updating details for user ${email}`);
+          await sql`
+            UPDATE "User" 
+            SET "avatarUrl" = ${maybeAvatarUrl},
+                "isMentionable" = ${maybeUserFromGoogle.isMentionable},
+                "firstName" = ${maybeUserFromGoogle.firstName},
+                "lastName" = ${maybeUserFromGoogle.lastName},
+                "googleID" = ${maybeUserFromGoogle.googleID}
+            WHERE "email" = ${email}
+          `.catch(handleUpsertError(maybeUserFromDatabase));
+        }
+      } else if (maybeUserFromDatabase?.isMentionable) {
+        console.log(
+          `User ${email} has been removed from Google, so marking as not mentionable and removing Google ID`
+        );
         await sql`
-            INSERT INTO "User" ${sql(
-              maybeAvatarUrl
-                ? { ...userToUpsert, avatarUrl: maybeAvatarUrl }
-                : userToUpsert
-            )}
-            ON CONFLICT ("email")
-            DO UPDATE SET
-            "firstName"=${user.firstName},
-            "lastName"=${user.lastName},
-            "googleID"=${user.googleID},
-            "isMentionable"=${user.isMentionable},
-            "avatarUrl"=${maybeAvatarUrl || null}
-        `.catch(handleError);
-      } else {
+                    UPDATE "User"
+                    SET "isMentionable" = false, "googleID" = null
+                    WHERE "email" = ${email}
+                `.catch(handleUpsertError(maybeUserFromDatabase));
+      } else if (maybeUserFromDatabase?.googleID) {
+        console.log(
+          `User ${email} has been removed from Google, so removing Google ID`
+        );
         await sql`
-            UPDATE "User"
-            SET "isMentionable"=${user.isMentionable}
-            WHERE "email" = ${user.email}
-        `.catch(handleError);
+                    UPDATE "User"
+                    SET "googleID" = null
+                    WHERE "email" = ${email}
+                `.catch(handleUpsertError(maybeUserFromDatabase));
+      } else if (!maybeUserFromDatabase) {
+        console.log(`Inserting details for user ${email}`);
+        const names = extractNamesWithFallback(email);
+        const user = {
+          googleID: null,
+          avatarUrl: null,
+          email,
+          ...names,
+          isMentionable: false,
+        };
+        await sql`
+            INSERT INTO "User" ${sql(user)}
+          `.catch(handleUpsertError(user));
       }
     }
   } catch (e) {

--- a/users-refresher-lambda/src/util.ts
+++ b/users-refresher-lambda/src/util.ts
@@ -1,0 +1,40 @@
+import { admin_directory_v1 } from "@googleapis/admin";
+
+export interface WithNames {
+  firstName: string;
+  lastName: string;
+}
+
+export interface User extends WithNames {
+  email: string;
+  isMentionable: boolean;
+  avatarUrl?: string | null;
+  googleID: string | null; // null denotes that the user is not in the Google directory (typically because they have left the organisation)
+}
+
+export interface UserLookup {
+  [email: string]: User;
+}
+
+export const extractNamesWithFallback = (
+  email: string,
+  names?: admin_directory_v1.Schema$UserName
+): WithNames => {
+  if (names && names.givenName && names.familyName) {
+    return {
+      firstName: names.givenName,
+      lastName: names.familyName,
+    };
+  }
+  const namePartOfEmail = email.split("@")?.[0];
+  const namePartsFromEmail = namePartOfEmail?.split(".");
+  return {
+    firstName: namePartsFromEmail[0] || namePartOfEmail,
+    lastName: namePartsFromEmail[1] || namePartOfEmail,
+  };
+};
+
+export const handleUpsertError = (user: User) => (error: Error) => {
+  console.error(`Error upserting user ${user.email}\n`, error);
+  console.error(user);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,6 +2337,14 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
   integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
 
+"@types/node-fetch@2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node-fetch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-3.0.3.tgz#9d969c9a748e841554a40ee435d26e53fa3ee899"
@@ -7981,7 +7989,14 @@ node-fetch@*, node-fetch@^3.2.0:
     fetch-blob "^3.1.4"
     formdata-polyfill "^4.0.10"
 
-node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.6.1:
+node-fetch@2, node-fetch@^2.3.0, node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -10283,6 +10298,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -10742,6 +10762,11 @@ web-streams-polyfill@^3.0.3:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
   integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -10917,6 +10942,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.5.0"


### PR DESCRIPTION
> **Warning**
> Before merging, someone must run `yarn database-setup` (at the root of the project) and choose `PROD` and then the `add googleID column to User table` option.

https://trello.com/c/IfRJvfZV/202-pinboard-mentions-phase-3-group-mentions

`users-refresher-lambda` had become a bit unwieldy with everything in a single file, this PR splits out the Google lookup behaviour into its own files and then refactors the logic for reconciling with DB to be a bit more readable/sensible (it also provides a more obvious home for the Google syncing portion of the upcoming 'group mentions' work).

Core to this refactoring was a shift away from individual calls to the [users.get](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/get) function of the Google Admin SDK Directory API (which needed to be limited to avoid exhausting the rate limit) to now use the [users.list](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users/list) function and page through (500 at a time) all the users with an `@guardian.co.uk` address and reconcile those with the users we're interested in (i.e. those with pinboard permission), which results in only a handful of API calls 😎 

As part of that refactoring we now properly detect when a user has their permission re-added (as attempted/failed to do in #189).

Lastly, we needed a way to know if a user is present in the Google directory (i.e. whether they've left the organisation) beyond them just being `isMentionable`:`false` - as this can be the case because they've had their permission removed for example - so we now store the users Google ID in a new `googleID` column of the `User` table. We also anticipate using `googleID`s in some way for the 'group mentions' implementation.

When working on this we observed the Google People API returns a non-stable photo URL for a handful of the users, which meant these users would be re-written to the DB every-time... gross. We've had a problem with very long avatar URLs elsewhere in the estate in the past, and I think these users are long serving at the org and probably set the avatars a long time ago (re-uploading their avatars will probably resolve the problem, as we noticed when working on https://github.com/guardian/frontend/pull/23162). As a workaround we download the avatar content when we detect such a difference and compare that before writing to DB (logging accordingly).

## How to test
Locally (ideally whilst this branch is NOT deployed to CODE, else it might get there first for some of the below because it runs every minute)...

...run `yarn watch` inside the `users-refresher-lambda` directory, you will be given the choice of `FULL RUN` or `process permission changes only` and then a choice of stage, choose `CODE`. 

- for `process permission changes only`
   - try first removing your pinboard permission in CODE, wait a few mins and run with this option, you should see some console output like `Permission removed for ${user.email}, so marking as not mentionable`
   - try restoring your pinboard permission in CODE, wait a few mins and run again with this option, you should see some console output like `Updating details for user ${email}`
   - try running for a final time without making any permission changes (assuming nobody else has changed pinboard permissions in that moment), you should see some console output like `NO PINBOARD PERMISSIONS CHANGED, exiting early`
   
- for `FULL RUN`, you should see a number of `...processing paged response, containing ${page?.data?.users?.length} users` and then owing to the issues explained in the Warning above you should see a see handful of users in the console in log lines like `Updating details for user ${email}`. If you really wanted to be thorough you could change your avatar in Google and run with this option and see that you get updated accordingly.
