### PR TITLE
add overall type check to `pre-commit` hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,9 @@ set -e
 
 yarn lint-staged
 
-if (git diff --name-only --cached | grep -e 'cdk' -e 'shared/graphql'); then 
+yarn type-check
+
+if (git diff --name-only --cached | grep -e 'cdk' -e 'shared/graphql'); then
     yarn workspace cdk update-snapshot
     git add cdk/test/__snapshots__/
 fi

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -5,9 +5,12 @@
   "repository": "https://github.com/guardian/editorial-tools-pinboard",
   "license": "MIT",
   "scripts": {
-    "test": "tsc --noEmit & jest",
-    "watch": "tsc --noEmit --watch & jest --watch",
-    "build": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts'",
+    "type-check": "tsc --noEmit",
+    "jest": "jest",
+    "test": "run-p --print-label type-check jest",
+    "watch": "yarn test -- --watch",
+    "synth": "cdk synth --path-metadata false --version-reporting false --app 'npx ts-node cdk.ts'",
+    "build": "run-p --print-label type-check synth",
     "update-snapshot": "jest -u"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "watch-bootstrapping-lambda": "yarn --cwd 'bootstrapping-lambda' watch 2>&1",
     "watch": "run-p --print-label watch-client watch-bootstrapping-lambda",
     "test": "wsrun --parallel --fast-exit --prefix --report --exclude-missing test ",
+    "type-check": "wsrun --parallel --fast-exit --prefix --report type-check",
     "build": "wsrun --parallel --fast-exit --prefix --report build ",
     "prepare": "husky install",
     "database-setup": "ts-node-dev shared/database/local/runDatabaseSetup.ts",


### PR DESCRIPTION
It was annoying having type errors make it into CI so we now type-check in the `pre-commit` hook (like we lint etc.)