### PR TITLE
remove redundant top-level `onCreateItem` subscription

### DIFF
--- a/client/gql.ts
+++ b/client/gql.ts
@@ -35,10 +35,7 @@ const itemReturnFields = `
   payload
   mentions
 `;
-const mentionReturnFields = `
-  pinboardId
-  mentions
-`;
+
 // TODO: consider updating the resolver (cdk/stack.ts) to use a Query with a secondary index (if performance degrades when we have lots of items)
 export const gqlGetInitialItems = (pinboardId: string) => gql`
   query MyQuery {
@@ -55,16 +52,9 @@ export const gqlCreateItem = gql`
     }
   }
 `;
-export const gqlOnCreateItem = (pinboardId?: string) =>
-  pinboardId
-    ? gql`
+export const gqlOnCreateItem = (pinboardId: string) => gql`
   subscription OnCreateItem {
     onCreateItem(pinboardId: "${pinboardId}") { ${itemReturnFields} }
-  }
-`
-    : gql`
-  subscription OnCreateItem {
-    onCreateItem { ${mentionReturnFields} }
   }
 `;
 

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -136,7 +136,7 @@ export function mount({
     });
 
     if (networkError) {
-      console.error(`[Apollo - Network error]: ${networkError}`);
+      console.error(`[Apollo - Network error]`, networkError);
       pinboardSpecificSentryClient.captureException(networkError);
     }
   });

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -4,7 +4,6 @@ import {
   useLazyQuery,
   useMutation,
   useQuery,
-  useSubscription,
 } from "@apollo/client";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { Item, MyUser } from "../../shared/graphql/graphql";
@@ -12,7 +11,6 @@ import {
   gqlAddManuallyOpenedPinboardIds,
   gqlGetPinboardByComposerId,
   gqlGetPinboardsByIds,
-  gqlOnCreateItem,
   gqlRemoveManuallyOpenedPinboardIds,
 } from "../gql";
 import type { PayloadAndType } from "./types/PayloadAndType";
@@ -374,20 +372,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     setUnreadFlag(pinboardIdToClose)(undefined);
     setError(pinboardIdToClose, undefined);
   };
-
-  useSubscription(gqlOnCreateItem(), {
-    onSubscriptionData: ({ subscriptionData }) => {
-      const { pinboardId, mentions } = subscriptionData.data.onCreateItem;
-
-      const isMentioned = mentions.includes(userEmail); // TODO also check group membership here (once added)
-
-      const pinboardIsOpen = isExpanded && selectedPinboardId === pinboardId;
-
-      if (isMentioned && !pinboardIsOpen) {
-        setUnreadFlag(pinboardId)(true);
-      }
-    },
-  });
 
   useEffect(() => {
     window.addEventListener("message", (event) => {

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -60,7 +60,6 @@ export const Pinboard: React.FC<PinboardProps> = ({
     addManuallyOpenedPinboardId,
   } = useGlobalStateContext();
 
-  // TODO: extract to floaty level?
   const itemSubscription = useSubscription(gqlOnCreateItem(pinboardId), {
     onSubscriptionData: ({ subscriptionData }) => {
       const itemFromSubscription: Item = subscriptionData.data.onCreateItem;


### PR DESCRIPTION
Co-authored-by: @aracho1 
Co-authored-by: @phillipbarron 

Not only was it redundant (because mentions force their way onto people's `manuallyOpenedPinboardIds` which are subscribed to separately) but also inefficient since everyone hears about ALL new messages (on all pinboards) which would likely be a problem when pinboard is popular in PROD

PLUS improved `[Apollo - Network error]` console.error message (used to print `[object Object]` now prints actual error object.
