### PR TITLE
run `yarn graphql-refresh` in precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,9 +5,8 @@ set -e
 
 yarn lint-staged
 
-yarn type-check
-
 if (git diff --name-only --cached | grep -e 'cdk' -e 'shared/graphql'); then
+    yarn graphql-refresh
     yarn workspace cdk update-snapshot
     git add cdk/test/__snapshots__/
 fi
@@ -17,3 +16,5 @@ if (git diff --name-only --cached | grep 'yarn.lock'); then
     git add yarn.lock
     yarn workspace client analyze-main-client-bundle
 fi
+
+yarn type-check


### PR DESCRIPTION
...to ensure precommit type check doesn't fail based on the generated GraphQL TS types