### PR TITLE
Group mentions

### DIFF
--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -1068,7 +1068,7 @@ type Query {
   listItems(pinboardId: String!): [Item]
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
-  searchMentionableUsers(prefix: String!): [User]
+  searchMentionableUsers(prefix: String!): UsersAndGroups
   getUsers(emails: [String!]!): [User]
 
   listPinboards(searchText: String): [WorkflowStub]
@@ -1109,6 +1109,7 @@ type Item {
   userEmail: String!
   pinboardId: String!
   mentions: [String!]
+  groupMentions: [String!]
 }
 
 type LastItemSeenByUser {
@@ -1132,6 +1133,17 @@ type MyUser {
   avatarUrl: String
   hasWebPushSubscription: Boolean
   manuallyOpenedPinboardIds: [String!]
+}
+
+type Group {
+  shorthand: String!
+  name: String!
+  memberEmails: [String!]!
+}
+
+type UsersAndGroups {
+  users: [User!]!
+  groups: [Group!]!
 }
 
 type WorkflowStub {
@@ -1168,6 +1180,7 @@ input CreateItemInput {
   type: String!
   pinboardId: String!
   mentions: [String!]
+  groupMentions: [String!]
 }
 
 input LastItemSeenByUserInput {
@@ -1220,7 +1233,7 @@ input LastItemSeenByUserInput {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1241,7 +1254,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1262,7 +1275,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1283,7 +1296,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1304,7 +1317,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1325,7 +1338,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1346,7 +1359,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1367,7 +1380,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1388,7 +1401,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1409,7 +1422,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1534,7 +1547,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1659,7 +1672,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1680,7 +1693,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1701,7 +1714,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 9d94ad84520d1d6a1d7b68fc8f81598e
+        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -1100,6 +1100,11 @@ type Subscription {
   ): MyUser @aws_subscribe(mutations: [\\"addManuallyOpenedPinboardIds\\", \\"removeManuallyOpenedPinboardIds\\"])
 }
 
+type MentionHandle {
+  label: String!
+  isMe: Boolean!
+}
+
 type Item {
   id: ID!
   message: String
@@ -1108,8 +1113,8 @@ type Item {
   type: String!
   userEmail: String!
   pinboardId: String!
-  mentions: [String!]
-  groupMentions: [String!]
+  mentions: [MentionHandle!]
+  groupMentions: [MentionHandle!]
 }
 
 type LastItemSeenByUser {
@@ -1233,7 +1238,7 @@ input LastItemSeenByUserInput {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1254,7 +1259,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1275,7 +1280,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1296,7 +1301,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1317,7 +1322,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1338,7 +1343,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1359,7 +1364,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1380,7 +1385,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1401,7 +1406,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1422,7 +1427,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1547,7 +1552,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1672,7 +1677,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1693,7 +1698,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1714,7 +1719,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 0eff2a5bb76f1d07c7ee475d5b0c2168
+        "ResponseMappingTemplate": "## schema checksum : 000d4eaaec8f647e8aec85e31f17f4e7
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -34,6 +34,7 @@ const itemReturnFields = `
   message
   payload
   mentions
+  groupMentions
 `;
 
 // TODO: consider updating the resolver (cdk/stack.ts) to use a Query with a secondary index (if performance degrades when we have lots of items)

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -73,8 +73,15 @@ const myUserReturnFields = `${userReturnFields}
 export const gqlSearchMentionableUsers = (prefix: string) => gql`
     query MyQuery {
         searchMentionableUsers(prefix: "${prefix}") {
+          users {
             ${userReturnFields}
-            isMentionable
+            isMentionable 
+          }
+          groups {
+            shorthand
+            name
+            memberEmails
+          }
         }
     }
 `;

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -33,8 +33,14 @@ const itemReturnFields = `
   pinboardId
   message
   payload
-  mentions
-  groupMentions
+  mentions {
+    label
+    isMe
+  }
+  groupMentions {
+    label
+    isMe
+  }
 `;
 
 // TODO: consider updating the resolver (cdk/stack.ts) to use a Query with a secondary index (if performance degrades when we have lots of items)

--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -1,44 +1,35 @@
 import { css } from "@emotion/react";
 import { neutral } from "@guardian/source-foundations";
 import React from "react";
-import { User } from "../../shared/graphql/graphql";
+import { Group, User } from "../../shared/graphql/graphql";
 import { composer } from "../colours";
 import { agateSans } from "../fontNormaliser";
+import { isUser } from "../../shared/graphql/extraTypes";
 
 interface AvatarRoundelProps {
-  maybeUser: User | undefined;
+  maybeUserOrGroup: User | Group | undefined;
   size: number;
-  userEmail: string;
-  shouldHideTooltip?: true;
+  fallback: string;
 }
 
 export const AvatarRoundel = ({
-  maybeUser,
+  maybeUserOrGroup,
   size,
-  userEmail,
-  shouldHideTooltip,
-}: AvatarRoundelProps) => {
-  const tooltip = shouldHideTooltip
-    ? undefined
-    : `${
-        maybeUser ? `${maybeUser.firstName} ${maybeUser.lastName}` : userEmail
-      }`;
-
-  return maybeUser?.avatarUrl ? (
+  fallback,
+}: AvatarRoundelProps) =>
+  maybeUserOrGroup && isUser(maybeUserOrGroup) && maybeUserOrGroup.avatarUrl ? (
     <img
-      key={userEmail}
+      key={fallback}
       css={css`
         border-radius: 50%;
         width: ${size}px;
         height: ${size}px;
       `}
-      title={tooltip}
-      src={maybeUser?.avatarUrl}
+      src={maybeUserOrGroup.avatarUrl}
       draggable={false}
     />
   ) : (
     <span
-      title={tooltip}
       css={css`
         width: ${size}px;
         height: ${size}px;
@@ -50,14 +41,23 @@ export const AvatarRoundel = ({
         flex-shrink: 0;
         user-select: none;
         justify-content: center;
-        align-items: center;
         ${size < 20 // arbitrary breakpoint
           ? `${agateSans.xxsmall()} font-size: 10px;`
           : agateSans.small()}
+        line-height: ${size}px;
       `}
     >
-      {(maybeUser?.firstName || userEmail).charAt(0).toUpperCase()}
-      {maybeUser?.lastName?.charAt(0).toUpperCase()}
+      {maybeUserOrGroup ? (
+        isUser(maybeUserOrGroup) ? (
+          <React.Fragment>
+            {maybeUserOrGroup.firstName.charAt(0).toUpperCase()}
+            {maybeUserOrGroup.lastName?.charAt(0).toUpperCase()}
+          </React.Fragment>
+        ) : (
+          maybeUserOrGroup.memberEmails?.length
+        )
+      ) : (
+        fallback.charAt(0).toUpperCase()
+      )}
     </span>
   );
-};

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -1,10 +1,13 @@
-import { Item, LastItemSeenByUser, User } from "../../shared/graphql/graphql";
+import {
+  Item,
+  LastItemSeenByUser,
+  MentionHandle,
+} from "../../shared/graphql/graphql";
 import React, { Fragment } from "react";
 import { css } from "@emotion/react";
 import { PayloadDisplay } from "./payloadDisplay";
 import { PendingItem } from "./types/PendingItem";
 import { palette, space } from "@guardian/source-foundations";
-import { userToMentionHandle } from "./util";
 import { SeenBy } from "./seenBy";
 import { AvatarRoundel } from "./avatarRoundel";
 import { agateSans } from "../fontNormaliser";
@@ -18,7 +21,7 @@ import { FormattedDateTime } from "./formattedDateTime";
 import * as Sentry from "@sentry/react";
 import { UserLookup } from "./types/UserLookup";
 
-const userMentioned = (unread: boolean | undefined) => css`
+const meMentionedCSS = (unread: boolean | undefined) => css`
   color: white;
   padding: 2px 4px;
   border-radius: 50px;
@@ -57,27 +60,23 @@ const formattedText = (text: string) =>
   }, <></>);
 
 const formatMentionHandlesInText = (
-  userEmail: string,
-  mentions: User[],
+  mentionHandles: MentionHandle[],
   text: string
 ): JSX.Element => {
-  const [mentionUser, ...remainingMentions] = mentions;
-  if (mentionUser) {
-    const mentionHandle = userToMentionHandle(mentionUser);
+  const [maybeMentionHandle, ...remainingMentions] = mentionHandles;
+  if (maybeMentionHandle) {
     const formattedMentionHandle = (
       <strong
         css={
-          userEmail === mentionUser.email
-            ? userMentioned(false)
-            : otherUserMentioned
+          maybeMentionHandle.isMe ? meMentionedCSS(false) : otherUserMentioned
         }
       >
-        {mentionHandle}
+        {maybeMentionHandle.label}
       </strong>
     );
-    const partsBetweenMentionHandles = text.split(mentionHandle);
+    const partsBetweenMentionHandles = text.split(maybeMentionHandle.label);
     const formattedPartsBetweenMentionHandles = partsBetweenMentionHandles.map(
-      (part) => formatMentionHandlesInText(userEmail, remainingMentions, part)
+      (part) => formatMentionHandlesInText(remainingMentions, part)
     );
     return formattedPartsBetweenMentionHandles.reduce(
       (result, formattedPart) => (
@@ -114,7 +113,6 @@ const maybeConstructPayloadAndType = (
 interface ItemDisplayProps {
   item: Item | PendingItem;
   userLookup: UserLookup;
-  userEmail: string;
   seenBy: LastItemSeenByUser[] | undefined;
   maybePreviousItem: Item | PendingItem | undefined;
   scrollToBottomIfApplicable: () => void;
@@ -123,7 +121,6 @@ interface ItemDisplayProps {
 export const ItemDisplay = ({
   item,
   userLookup,
-  userEmail,
   seenBy,
   maybePreviousItem,
   scrollToBottomIfApplicable,
@@ -131,14 +128,14 @@ export const ItemDisplay = ({
   const user = userLookup?.[item.userEmail];
   const payloadAndType = maybeConstructPayloadAndType(item.type, item.payload);
   const isPendingSend = "pending" in item && item.pending;
-  const mentions = item.mentions
-    ?.map((mentionEmail) => userLookup?.[mentionEmail])
-    .filter((mentionUser): mentionUser is User => !!mentionUser);
+
+  const mentionHandles = [
+    ...(item.mentions || []),
+    ...(item.groupMentions || []),
+  ];
 
   const formattedMessage =
-    !item.message || !mentions
-      ? item.message
-      : formatMentionHandlesInText(userEmail, mentions, item.message);
+    item.message && formatMentionHandlesInText(mentionHandles, item.message);
 
   const dateInMillisecs = new Date(item.timestamp).valueOf();
 

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -165,9 +165,9 @@ export const ItemDisplay = ({
         {isDifferentUserFromPreviousItem && (
           <React.Fragment>
             <AvatarRoundel
-              maybeUser={user}
+              maybeUserOrGroup={user}
               size={28}
-              userEmail={item.userEmail}
+              fallback={item.userEmail}
             />
             <span
               css={css`

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -186,14 +186,17 @@ export const Pinboard: React.FC<PinboardProps> = ({
   );
   const hasError = !!errors[pinboardId];
 
-  const onSuccessfulSend = (pendingItem: PendingItem) => {
+  const onSuccessfulSend = (
+    pendingItem: PendingItem,
+    mentionEmails: string[]
+  ) => {
     setSuccessfulSends((previousSends) => [...previousSends, pendingItem]);
 
     // ensure any pinboard you contribute to ends up on your list of manually opened pinboards
     addManuallyOpenedPinboardId(pendingItem.pinboardId);
 
     // ensure any pinboard you're mentioned on ends up on your list of manually opened pinboards
-    pendingItem.mentions?.map((mentionEmail) =>
+    mentionEmails.map((mentionEmail) =>
       addManuallyOpenedPinboardId(pendingItem.pinboardId, mentionEmail)
     );
   };

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -204,7 +204,6 @@ export const ScrollableItems = ({
             key={item.id}
             item={item}
             userLookup={userLookup}
-            userEmail={userEmail}
             seenBy={lastItemSeenByUsersForItemIDLookup[item.id]}
             maybePreviousItem={items[index - 1]}
             scrollToBottomIfApplicable={scrollToBottomIfApplicable}

--- a/client/src/seenBy.tsx
+++ b/client/src/seenBy.tsx
@@ -10,7 +10,7 @@ import { formatDateTime } from "./util";
 import { UserLookup } from "./types/UserLookup";
 
 const maxSeenByIcons = 2;
-const roundelHeightPx = 15;
+const roundelHeightPx = 16;
 const roundelOverlapPct = 25;
 
 interface SeenByProps {
@@ -44,6 +44,7 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
           color: ${palette.neutral[20]};
           margin-right: 5px;
           ${agateSans.xxsmall({ lineHeight: "tight" })}
+          line-height: ${roundelHeightPx}px;
         `}
       >
         Seen by
@@ -53,15 +54,14 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
           key={userEmail}
           css={css`
             transform: translateX(-${i * roundelOverlapPct}%);
-            z-index: ${99999 - i};
+            z-index: ${maxSeenByIcons + 1 - i};
             height: ${roundelHeightPx}px;
           `}
         >
           <AvatarRoundel
-            maybeUser={userLookup?.[userEmail]}
+            maybeUserOrGroup={userLookup?.[userEmail]}
             size={roundelHeightPx}
-            userEmail={userEmail}
-            shouldHideTooltip
+            fallback={userEmail}
           />
         </div>
       ))}

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -12,7 +12,7 @@ import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
 export const userToMentionHandle = (user: User) =>
   `@${user.firstName} ${user.lastName}`;
 
-export const groupToMentionHandle = (group: Group) => `@${group.name}`;
+export const groupToMentionHandle = (group: Group) => `@${group.shorthand}`;
 
 export const getTooltipText = (pinboardData: PinboardData) =>
   `WT: ${pinboardData.title}` +

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,4 +1,4 @@
-import { User } from "../../shared/graphql/graphql";
+import { Group, User } from "../../shared/graphql/graphql";
 import { PinboardData } from "../../shared/graphql/extraTypes";
 import isThisYear from "date-fns/isThisYear";
 import isToday from "date-fns/isToday";
@@ -11,6 +11,8 @@ import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
 
 export const userToMentionHandle = (user: User) =>
   `@${user.firstName} ${user.lastName}`;
+
+export const groupToMentionHandle = (group: Group) => `@${group.name}`;
 
 export const getTooltipText = (pinboardData: PinboardData) =>
   `WT: ${pinboardData.title}` +

--- a/database-bridge-lambda/run.ts
+++ b/database-bridge-lambda/run.ts
@@ -1,17 +1,33 @@
 import { handler } from "./src";
 import { AppSyncResolverEvent } from "aws-lambda/trigger/appsync-resolver";
 import { createDatabaseTunnel } from "../shared/database/local/databaseTunnel";
+import prompts from "prompts";
+
+const baseInput = {
+  identity: { resolverContext: { userEmail: "foo@bar.com" } },
+};
+
+const sampleInputs = {
+  listItems: { pinboardId: "123" },
+  searchMentionableUsers: { prefix: "a" },
+};
 
 (async () => {
   await createDatabaseTunnel();
-  console.log(
-    "Testing tunnel with 'listItems' Query...\n",
-    await handler({
-      identity: { resolverContext: { userEmail: "foo@bar.com" } },
-      arguments: { pinboardId: "123" },
-      info: {
-        fieldName: "listItems",
-      },
-    } as AppSyncResolverEvent<unknown, unknown>)
-  );
+
+  const { inputPayload } = await prompts({
+    type: "select",
+    name: "inputPayload",
+    message: "Operation?",
+    choices: Object.entries(sampleInputs).map(([operation, sampleInput]) => ({
+      title: operation,
+      value: {
+        ...baseInput,
+        arguments: sampleInput,
+        info: { fieldName: operation },
+      } as AppSyncResolverEvent<unknown, unknown>,
+    })),
+  });
+
+  console.log(JSON.stringify(await handler(inputPayload), null, 2));
 })();

--- a/database-bridge-lambda/run.ts
+++ b/database-bridge-lambda/run.ts
@@ -8,26 +8,32 @@ const baseInput = {
 };
 
 const sampleInputs = {
-  listItems: { pinboardId: "123" },
+  listItems: { pinboardId: "63206" },
   searchMentionableUsers: { prefix: "a" },
 };
 
 (async () => {
   await createDatabaseTunnel();
 
-  const { inputPayload } = await prompts({
-    type: "select",
-    name: "inputPayload",
-    message: "Operation?",
-    choices: Object.entries(sampleInputs).map(([operation, sampleInput]) => ({
-      title: operation,
-      value: {
-        ...baseInput,
-        arguments: sampleInput,
-        info: { fieldName: operation },
-      } as AppSyncResolverEvent<unknown, unknown>,
-    })),
-  });
+  // noinspection InfiniteLoopJS
+  while (
+    // eslint-disable-next-line no-constant-condition
+    true
+  ) {
+    const { inputPayload } = await prompts({
+      type: "select",
+      name: "inputPayload",
+      message: "Operation?",
+      choices: Object.entries(sampleInputs).map(([operation, sampleInput]) => ({
+        title: operation,
+        value: {
+          ...baseInput,
+          arguments: sampleInput,
+          info: { fieldName: operation },
+        } as AppSyncResolverEvent<unknown, unknown>,
+      })),
+    });
 
-  console.log(JSON.stringify(await handler(inputPayload), null, 2));
+    console.log(JSON.stringify(await handler(inputPayload), null, 2));
+  }
 })();

--- a/database-bridge-lambda/src/index.ts
+++ b/database-bridge-lambda/src/index.ts
@@ -26,7 +26,7 @@ const run = (
     case "createItem":
       return createItem(sql, args, userEmail);
     case "listItems":
-      return listItems(sql, args);
+      return listItems(sql, args, userEmail);
     case "seenItem":
       return seenItem(sql, args, userEmail);
     case "listLastItemSeenByUsers":

--- a/database-bridge-lambda/src/sql/Item.ts
+++ b/database-bridge-lambda/src/sql/Item.ts
@@ -1,6 +1,49 @@
 import { CreateItemInput } from "../../../shared/graphql/graphql";
 import { Sql } from "../../../shared/database/types";
 
+const fragmentIndividualMentionsToMentionHandles = (
+  sql: Sql,
+  userEmail: string
+) => sql`
+    SELECT json_agg(
+        json_build_object(
+            'label', concat('@', "firstName", ' ', "lastName"),
+            'isMe', "email" = ${userEmail}
+        )
+    )
+    FROM "User"
+    WHERE "email" = ANY("mentions")
+`;
+
+const fragmentGroupMentionsToMentionHandles = (
+  sql: Sql,
+  userEmail: string
+) => sql`
+    SELECT json_agg(
+        json_build_object(
+            'label', concat('@', "shorthand"),
+            'isMe', EXISTS(
+                SELECT 1
+                FROM "User", "GroupMember"
+                WHERE "GroupMember"."groupShorthand" = "shorthand"
+                    AND "GroupMember"."userGoogleID" = "User"."googleID"
+                    AND "User"."email" = ${userEmail} 
+            )
+        )
+    )
+    FROM "Group"
+    WHERE "shorthand" = ANY("groupMentions")
+`;
+
+const fragmentItemFields = (sql: Sql, userEmail: string) => sql`
+    *, (${fragmentIndividualMentionsToMentionHandles(
+      sql,
+      userEmail
+    )}) as "mentions", (${fragmentGroupMentionsToMentionHandles(
+  sql,
+  userEmail
+)}) as "groupMentions"`;
+
 export const createItem = async (
   sql: Sql,
   args: { input: CreateItemInput },
@@ -8,11 +51,15 @@ export const createItem = async (
 ) =>
   sql`
     INSERT INTO "Item" ${sql({ userEmail, ...args.input })} 
-    RETURNING *
+    RETURNING ${fragmentItemFields(sql, userEmail)}
 `.then((rows) => rows[0]);
 
-export const listItems = (sql: Sql, args: { pinboardId: string }) => sql`
-    SELECT *
+export const listItems = (
+  sql: Sql,
+  args: { pinboardId: string },
+  userEmail: string
+) => sql`
+    SELECT ${fragmentItemFields(sql, userEmail)}
     FROM "Item"
     WHERE "pinboardId" = ${args.pinboardId}
 `;

--- a/notifications-lambda/run.ts
+++ b/notifications-lambda/run.ts
@@ -27,7 +27,7 @@ import { getYourEmail } from "../shared/local/yourEmail";
     item: {
       pinboardId: "63923",
       payload: null,
-      mentions: ["tom.richards@guardian.co.uk"],
+      mentions: [],
       groupMentions: [],
       userEmail: "tom.richards@guardian.co.uk",
       id: "535b86e2-4f01-4f60-a2d0-a5e4f5a7d312",

--- a/notifications-lambda/run.ts
+++ b/notifications-lambda/run.ts
@@ -28,6 +28,7 @@ import { getYourEmail } from "../shared/local/yourEmail";
       pinboardId: "63923",
       payload: null,
       mentions: ["tom.richards@guardian.co.uk"],
+      groupMentions: [],
       userEmail: "tom.richards@guardian.co.uk",
       id: "535b86e2-4f01-4f60-a2d0-a5e4f5a7d312",
       message: "testing one two three",

--- a/shared/graphql/extraTypes.ts
+++ b/shared/graphql/extraTypes.ts
@@ -1,4 +1,4 @@
-import type { WorkflowStub } from "./graphql";
+import type { Group, User, WorkflowStub } from "./graphql";
 
 export type PinboardData = WorkflowStub;
 
@@ -14,3 +14,9 @@ export const isPinboardData = (
   !!maybePinboardData &&
   maybePinboardData !== "loading" &&
   maybePinboardData !== "notTrackedInWorkflow";
+
+export const isGroup = (userOrGroup: User | Group): userOrGroup is Group =>
+  "shorthand" in userOrGroup;
+
+export const isUser = (userOrGroup: User | Group): userOrGroup is User =>
+  !isGroup(userOrGroup);

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -8,7 +8,7 @@ type Query {
   listItems(pinboardId: String!): [Item]
   listLastItemSeenByUsers(pinboardId: String!): [LastItemSeenByUser]
   getMyUser: MyUser
-  searchMentionableUsers(prefix: String!): [User]
+  searchMentionableUsers(prefix: String!): UsersAndGroups
   getUsers(emails: [String!]!): [User]
 
   listPinboards(searchText: String): [WorkflowStub]
@@ -49,6 +49,7 @@ type Item {
   userEmail: String!
   pinboardId: String!
   mentions: [String!]
+  groupMentions: [String!]
 }
 
 type LastItemSeenByUser {
@@ -72,6 +73,17 @@ type MyUser {
   avatarUrl: String
   hasWebPushSubscription: Boolean
   manuallyOpenedPinboardIds: [String!]
+}
+
+type Group {
+  shorthand: String!
+  name: String!
+  memberEmails: [String!]!
+}
+
+type UsersAndGroups {
+  users: [User!]!
+  groups: [Group!]!
 }
 
 type WorkflowStub {
@@ -108,6 +120,7 @@ input CreateItemInput {
   type: String!
   pinboardId: String!
   mentions: [String!]
+  groupMentions: [String!]
 }
 
 input LastItemSeenByUserInput {

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -40,6 +40,11 @@ type Subscription {
   ): MyUser @aws_subscribe(mutations: ["addManuallyOpenedPinboardIds", "removeManuallyOpenedPinboardIds"])
 }
 
+type MentionHandle {
+  label: String!
+  isMe: Boolean!
+}
+
 type Item {
   id: ID!
   message: String
@@ -48,8 +53,8 @@ type Item {
   type: String!
   userEmail: String!
   pinboardId: String!
-  mentions: [String!]
-  groupMentions: [String!]
+  mentions: [MentionHandle!]
+  groupMentions: [MentionHandle!]
 }
 
 type LastItemSeenByUser {


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @aracho1 

https://trello.com/c/IfRJvfZV/202-pinboard-mentions-phase-3-group-mentions

Now that we have groups (and members) thanks to https://github.com/guardian/pinboard/pull/203 we can now surface these in the client (in the `@` autocomplete when sending a message) to allows users to mention groups, via the following changes...

- changing the return type of the `searchMentionableUsers` query from array of `User` to a new type `UsersAndGroups` (with `users` and `groups` array properties) and updated the DB query to populate the groups section when there's a match on `shorthand`, `name`, `primaryEmail` or any of the `otherEmail` - see #203 for more on these fields)
- refactoring the `mentions` `Item` type from a string array to be an array of `MentionHandle` - which is a new type containing a `label` and `isMe` property, which we calculate server-side which in turn keeps the client cleaner (NOTE we continue to store just a string array for the `mentions` column in the DB, its just transformed on the way out now).
- adding a `groupMentions` property to the `Item` type, which is also an array of `MentionHandle` as above
- update the `AvatarRoundel` to also handle Groups and render them as a circle with the member count within
- **send a 'web push'/desktop notification whenever user is a member of a group mention**
- refactor the autocomplete component (`Suggestion`) to be able to display a user or a group, where the group displays the shorthand as the main heading and the 'name' (as it appears in gmail etc.) as the subheading, with the tooltip being a list of member's email addresses. This also includes logic to detect whether the suggestion is the first of that type (user or group) and display an additional heading row...
![image](https://user-images.githubusercontent.com/19289579/200331024-493b7c05-cc35-4fd4-a1a3-950ca1c73251.png)
