### PR TITLE
display unread from team pinboards

### DIFF
--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -1217,6 +1217,7 @@ type PinboardIdWithClaimCounts {
   othersClaimedCount: Int!
   notClaimableCount: Int!
   latestGroupMentionItemId: String!
+  hasUnread: Boolean!
 }
 ",
       },
@@ -1264,7 +1265,7 @@ type PinboardIdWithClaimCounts {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1285,7 +1286,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "claimItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1306,7 +1307,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1327,7 +1328,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1348,7 +1349,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1369,7 +1370,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1390,7 +1391,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getGroupPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1411,7 +1412,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1432,7 +1433,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1453,7 +1454,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1474,7 +1475,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1495,7 +1496,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1620,7 +1621,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1745,7 +1746,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1766,7 +1767,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1787,7 +1788,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 4502d6f3e7e29721ce2d075777dbb793
+        "ResponseMappingTemplate": "## schema checksum : 2e8c34822b11589924f4235b9206d36c
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -33,6 +33,7 @@ export const gqlGetGroupPinboardIds = gql`
       othersClaimedCount
       notClaimableCount
       latestGroupMentionItemId
+      hasUnread
     }
   }
 `;

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -42,6 +42,7 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
     activeTab,
     setActiveTab,
     boundedPositionTranslation,
+    setUnreadFlag,
   } = useGlobalStateContext();
 
   const selectedPinboard = activePinboards.find(
@@ -78,6 +79,12 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
 
   const groupPinboardIdsWithClaimCounts: PinboardIdWithClaimCounts[] =
     groupPinboardIdsQuery.data?.getGroupPinboardIds || [];
+
+  useEffect(() => {
+    groupPinboardIdsWithClaimCounts.forEach(({ pinboardId, hasUnread }) =>
+      setUnreadFlag(pinboardId)(hasUnread)
+    );
+  }, [groupPinboardIdsWithClaimCounts]);
 
   const [isShowAllTeamPinboards, setIsShowAllTeamPinboards] = useState(false);
   const unclaimedCount = groupPinboardIdsWithClaimCounts.filter(

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -75,7 +75,9 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const isTopHalf =
     Math.abs(boundedPositionTranslation.y) > window.innerHeight / 2;
 
-  const groupPinboardIdsQuery = useQuery(gqlGetGroupPinboardIds);
+  const groupPinboardIdsQuery = useQuery(gqlGetGroupPinboardIds, {
+    pollInterval: 5000, // always poll this one, to ensure we get unread flags even when pinboard is not expanded
+  });
 
   const groupPinboardIdsWithClaimCounts: PinboardIdWithClaimCounts[] =
     groupPinboardIdsQuery.data?.getGroupPinboardIds || [];
@@ -135,12 +137,9 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
 
   useEffect(() => {
     if (isExpanded) {
-      groupPinboardIdsQuery.refetch();
       pinboardDataQuery.refetch();
-      groupPinboardIdsQuery.startPolling(5000);
       pinboardDataQuery.startPolling(5000);
     } else {
-      groupPinboardIdsQuery.stopPolling();
       pinboardDataQuery.stopPolling();
     }
   }, [

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -281,14 +281,10 @@ export const SelectPinboard = ({
           {unreadFlags[pinboardData.id] && (
             <div
               css={{
-                height: "16px",
-                lineHeight: "16px",
-                minWidth: "8px", // doesn't include padding
-                borderRadius: "8px",
+                height: "10px",
+                width: "10px",
+                borderRadius: "5px",
                 backgroundColor: palette.neutral["20"],
-                color: palette.neutral["100"],
-                textAlign: "center",
-                padding: "0 4px",
                 marginRight: "2px",
               }}
             >

--- a/database-bridge-lambda/src/sql/Item.ts
+++ b/database-bridge-lambda/src/sql/Item.ts
@@ -122,22 +122,28 @@ export const getGroupPinboardIds = async (
         END) as "countType", count(*) as "count", MAX("id") as "latestGroupMentionItemId", NOT EXISTS(
             SELECT 1
             FROM "LastItemSeenByUser"
-            WHERE "LastItemSeenByUser"."pinboardId" = "pinboardId"
+            WHERE "LastItemSeenByUser"."pinboardId" = "Item"."pinboardId"
               AND "LastItemSeenByUser"."userEmail" = ${userEmail}
-              AND "LastItemSeenByUser"."itemID" >= MAX("id")
+              AND "LastItemSeenByUser"."itemID" >= MAX("Item"."id")
         ) as "hasUnread"
       FROM "Item"
-      WHERE EXISTS(
+      WHERE "type" != 'claim'
+        AND EXISTS(
           SELECT 1
           FROM "User" INNER JOIN "GroupMember" ON "GroupMember"."userGoogleID" = "User"."googleID"
           WHERE "GroupMember"."groupShorthand" = ANY ("groupMentions")
             AND "User"."email" = ${userEmail}
         )
       GROUP BY "pinboardId", "countType"
-  `.then((rows) =>
-    Object.values(
-      rows.reduce(
-        (acc, row) => ({
+  `.then((rows) => {
+    console.table(rows);
+    return Object.values(
+      rows.reduce((acc, row) => {
+        const isRowUnclaimedOrInformational =
+          ["unclaimedCount", "notClaimableCount"].includes(row.countType) &&
+          row.count > 0;
+
+        return {
           ...acc,
           [row.pinboardId]: {
             ...(acc[row.pinboardId] || {
@@ -154,10 +160,11 @@ export const getGroupPinboardIds = async (
                   acc[row.pinboardId].latestGroupMentionItemId
                 )
               : row.latestGroupMentionItemId,
-            hasUnread: acc[row.pinboardId]?.hasUnread ? true : row.hasUnread,
+            hasUnread: acc[row.pinboardId]?.hasUnread
+              ? true
+              : isRowUnclaimedOrInformational && row.hasUnread,
           },
-        }),
-        {} as Record<string, PinboardIdWithClaimCounts>
-      )
-    )
-  );
+        };
+      }, {} as Record<string, PinboardIdWithClaimCounts>)
+    );
+  });

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -157,4 +157,5 @@ type PinboardIdWithClaimCounts {
   othersClaimedCount: Int!
   notClaimableCount: Int!
   latestGroupMentionItemId: String!
+  hasUnread: Boolean!
 }


### PR DESCRIPTION
Co-authored-by: @aracho1 

https://trello.com/c/IfRJvfZV/202-pinboard-mentions-phase-3-group-mentions

Now that we have the `MY TEAMS' PINBOARDS` list on the `SelectPinboard` view (thanks to #206), we want to be able to surface any unread group mentions which are unclaimed or informational via our existing unread flag mechanism (i.e. a red blob on the Floaty and a black blob on the relevant pinboard button on the `SelectPinboard` view).

- tweak `getGroupPinboardIds` query to include `hasUnread` property (for unclaimed or informational group mentions only) - unread being calculated by doing an inner query on the `LastItemSeenByUser` table
- poll the above every 5s, regardless of whether pinboard is expanded
- utilise those `hasUnread` values when processing the `getGroupPinboardIds` response, calling the existing `setUnreadFlag` for each pinboard
- change the sort function for the `MY TEAMS' PINBOARDS` list to place unread at the top

ALSO INCLUDES changes from https://github.com/guardian/pinboard/pull/211 (due to an accidental/premature merge of chained PR)
