### PR TITLE
load `Guardian Agate Sans` font (if not already loaded by host platform)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,6 @@ set -e
 yarn lint-staged
 
 if (git diff --name-only --cached | grep -e 'cdk' -e 'shared/graphql'); then
-    yarn graphql-refresh
     yarn workspace cdk update-snapshot
     git add cdk/test/__snapshots__/
 fi
@@ -17,4 +16,5 @@ if (git diff --name-only --cached | grep 'yarn.lock'); then
     yarn workspace client analyze-main-client-bundle
 fi
 
+yarn graphql-refresh
 yarn type-check

--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -4,24 +4,6 @@
     <meta charset="UTF-8" />
     <title>PinBoard</title>
     <script src="https://pinboard.local.dev-gutools.co.uk/pinboard.loader.js"></script>
-    <style>
-      @font-face {
-        font-family: "Guardian Agate Sans";
-        src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianAgateSans1Web/GuardianAgateSans1Web-Regular.woff2")
-          format("woff2");
-        font-weight: 400;
-        font-style: normal;
-        font-display: swap;
-      }
-      @font-face {
-        font-family: "Guardian Agate Sans";
-        src: url("https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianAgateSans1Web/GuardianAgateSans1Web-Bold.woff2")
-          format("woff2");
-        font-weight: 700;
-        font-style: normal;
-        font-display: swap;
-      }
-    </style>
   </head>
 
   <body>

--- a/client/fontNormaliser.ts
+++ b/client/fontNormaliser.ts
@@ -5,19 +5,28 @@ import type {
 
 // eslint-disable-next-line no-restricted-imports -- suppress our own lint rule as this is the one legit place to import the fonts
 import * as sourceFoundations from "@guardian/source-foundations";
+import { css } from "@emotion/react";
 
 type FontOverride = (
   originalFunc: FontScaleFunctionStr
 ) => (options?: FontScaleArgs | undefined) => string;
 
+// different tools provide Agate Sans either with or without the Web suffix, so use fallbacks to try both.
+const agateFontNameVariants = [
+  "Guardian Agate Sans",
+  "Guardian Agate Sans Web",
+  "GuardianAgateSans1Web",
+];
+
 // source foundations will give us Guardian Text Sans, but we usually want Guardian Agate Sans, so as to fit in with
 // the tools hosting pinboard.
-// different tools provide Agate Sans either with or without the Web suffix, so use fallbacks to try both.
 const overrideToAgateSans: FontOverride = (
   originalFunc: FontScaleFunctionStr
 ) => (options?: FontScaleArgs) => `
   ${originalFunc(options)};
-  font-family: "Guardian Agate Sans", "Guardian Agate Sans Web", Arial, sans-serif;
+  font-family: ${agateFontNameVariants
+    .map((_) => `"${_}"`)
+    .join(",")}, Arial, sans-serif;
 `;
 
 const defaultToPx: FontOverride = (originalFunc: FontScaleFunctionStr) => (
@@ -44,6 +53,42 @@ export const agateSans = agateSansFont(
   pixelSizedFont(sourceFoundations.textSans)
 );
 export const textSans = pixelSizedFont(sourceFoundations.textSans);
-export const headline = pixelSizedFont(sourceFoundations.headline);
-export const titlepiece = pixelSizedFont(sourceFoundations.titlepiece);
-export const body = pixelSizedFont(sourceFoundations.body);
+
+const agateFontFileBasePath =
+  "https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianAgateSans1Web/GuardianAgateSans1Web-";
+export const getAgateFontFaceIfApplicable = () =>
+  agateFontNameVariants.find((agateVariant) =>
+    document.fonts.check(`12px "${agateVariant}"`)
+  )
+    ? null
+    : css`
+        @font-face {
+          font-family: "Guardian Agate Sans";
+          src: url("${agateFontFileBasePath}Regular.woff2") format("woff2");
+          font-weight: 400;
+          font-style: normal;
+          font-display: swap;
+        }
+        @font-face {
+          font-family: "Guardian Agate Sans";
+          src: url("${agateFontFileBasePath}Bold.woff2") format("woff2");
+          font-weight: 700;
+          font-style: normal;
+          font-display: swap;
+        }
+        @font-face {
+          font-family: "Guardian Agate Sans";
+          src: url("${agateFontFileBasePath}RegularItalic.woff2")
+            format("woff2");
+          font-weight: 400;
+          font-style: italic;
+          font-display: swap;
+        }
+        @font-face {
+          font-family: "Guardian Agate Sans";
+          src: url("${agateFontFileBasePath}BoldItalic.woff2") format("woff2");
+          font-weight: 700;
+          font-style: italic;
+          font-display: swap;
+        }
+      `;

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import root from "react-shadow/emotion";
 import { PayloadAndType } from "./types/PayloadAndType";
 import { ASSET_HANDLE_HTML_TAG, ButtonPortal } from "./addToPinboardButton";
@@ -37,6 +37,8 @@ import {
 } from "../../shared/constants";
 import { UserLookup } from "./types/UserLookup";
 import { gqlGetUsers } from "../gql";
+import { getAgateFontFaceIfApplicable } from "../fontNormaliser";
+import { Global } from "@emotion/react";
 
 const PRESELECT_PINBOARD_HTML_TAG = "pinboard-preselect";
 const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
@@ -299,9 +301,12 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
     );
   }, [preSelectedComposerId, composerSection]);
 
+  const agateFontFaceIfApplicable = useMemo(getAgateFontFaceIfApplicable, []);
+
   return (
     <TelemetryContext.Provider value={sendTelemetryEvent}>
       <ApolloProvider client={apolloClient}>
+        <Global styles={agateFontFaceIfApplicable} />
         <HiddenIFrameForServiceWorker iFrameRef={serviceWorkerIFrameRef} />
         <root.div
           onDragOver={(event) =>


### PR DESCRIPTION
Co-authored-by: @aracho1 

https://trello.com/c/am4GCw1H/946-load-agate-fonts-in-pinboard

During a recent demo we noticed pinboard (within grid) was displaying with basic sans font (rather than `Guardian Agate Sans`) because Pinboard previously relied upon the host platform to load the Agate font, but since https://github.com/guardian/grid/pull/3893 we cannot rely on this.

This PR moves the approach used for the local testing playground (loading the Agate fonts from `interactive.guim.co.uk`) to the top level of the React tree (in `app.tsx`). Note that the `@font-face` declarations need to be made outside of the shadow DOM due to browser restrictions.