### PR TITLE
check whether Agate is loaded a different way (to fix in Firefox)

### DIFF
--- a/client/fontNormaliser.ts
+++ b/client/fontNormaliser.ts
@@ -54,12 +54,19 @@ export const agateSans = agateSansFont(
 );
 export const textSans = pixelSizedFont(sourceFoundations.textSans);
 
+const isAgateLoaded = () => {
+  let foundAgate = false;
+  document.fonts.forEach((font) => {
+    if (agateFontNameVariants.includes(font.family)) {
+      foundAgate = true;
+    }
+  });
+  return foundAgate;
+};
 const agateFontFileBasePath =
   "https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianAgateSans1Web/GuardianAgateSans1Web-";
 export const getAgateFontFaceIfApplicable = () =>
-  agateFontNameVariants.find((agateVariant) =>
-    document.fonts.check(`12px "${agateVariant}"`)
-  )
+  isAgateLoaded()
     ? null
     : css`
         @font-face {


### PR DESCRIPTION
It turns out the [`document.fonts.check`](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/check) (used in https://github.com/guardian/pinboard/pull/212) has different behaviour between Chrome and Firefox and so falls foul of https://bugzilla.mozilla.org/show_bug.cgi?id=1252821. This PR changes the way it checks whether Agate is loaded, that is consistent between browsers... sigh.

✅  TESTED in CODE (both Chrome & Firefox) and in Grid (loads the font) Composer (doesn't load the font, because its already loaded) 