### PR TITLE
use `ResizeObserver` for the `scrollToBottomIfApplicable` behaviour for greater reliability

### DIFF
--- a/client/src/grid/gridDynamicSearchDisplay.tsx
+++ b/client/src/grid/gridDynamicSearchDisplay.tsx
@@ -14,10 +14,6 @@ import { FormattedDateTime } from "../formattedDateTime";
 import { GridBadge } from "./gridBadges";
 import { SvgReload } from "@guardian/source-react-components";
 
-type GridDynamicSearchDisplayProps = Pick<DynamicGridPayload, "payload"> & {
-  scrollToBottomIfApplicable: undefined | (() => void);
-};
-
 const formatChip = (chip: GridBadgeData) => {
   if (chip.text.match(/^[+-]/i)) {
     return chip;
@@ -28,8 +24,7 @@ const formatChip = (chip: GridBadgeData) => {
 
 export const GridDynamicSearchDisplay = ({
   payload,
-  scrollToBottomIfApplicable,
-}: GridDynamicSearchDisplayProps) => {
+}: Pick<DynamicGridPayload, "payload">) => {
   const [
     gridSearchSummaryLastChecked,
     setGridSearchSummaryLastChecked,
@@ -74,8 +69,6 @@ export const GridDynamicSearchDisplay = ({
 
   const maybeQueryBreakdown = maybeGridSearchSummary?.queryBreakdown;
 
-  useLayoutEffect(() => scrollToBottomIfApplicable?.(), [maybeQueryBreakdown]);
-
   return (
     <React.Fragment>
       <div
@@ -96,7 +89,6 @@ export const GridDynamicSearchDisplay = ({
               height: "100%",
             }}
             draggable={false}
-            onLoad={scrollToBottomIfApplicable}
           />
         ))}
       </div>

--- a/client/src/grid/gridStaticImageDisplay.tsx
+++ b/client/src/grid/gridStaticImageDisplay.tsx
@@ -5,15 +5,10 @@ import CropIcon from "../../icons/crop.svg";
 import PictureIcon from "../../icons/picture.svg";
 import { palette } from "@guardian/source-foundations";
 
-type GridStaticImageDisplayProps = StaticGridPayload & {
-  scrollToBottomIfApplicable: undefined | (() => void);
-};
-
 export const GridStaticImageDisplay = ({
   type,
   payload,
-  scrollToBottomIfApplicable,
-}: GridStaticImageDisplayProps) => (
+}: StaticGridPayload) => (
   <React.Fragment>
     <img
       src={payload.thumbnail}
@@ -23,7 +18,6 @@ export const GridStaticImageDisplay = ({
         height: 100%;
       `}
       draggable={false}
-      onLoad={scrollToBottomIfApplicable}
       // TODO: hover for larger thumbnail
     />
 

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -51,7 +51,6 @@ interface ItemDisplayProps {
   userLookup: UserLookup;
   seenBy: LastItemSeenByUser[] | undefined;
   maybePreviousItem: Item | PendingItem | undefined;
-  scrollToBottomIfApplicable: () => void;
   claimItem: () => Promise<FetchResult<{ claimItem: Claimed }>>;
   maybeRelatedItem: Item | false | undefined;
   userEmail: string;
@@ -64,7 +63,6 @@ export const ItemDisplay = ({
   userLookup,
   seenBy,
   maybePreviousItem,
-  scrollToBottomIfApplicable,
   claimItem,
   maybeRelatedItem,
   userEmail,
@@ -191,11 +189,7 @@ export const ItemDisplay = ({
           )}
         </div>
         {payloadAndType && (
-          <PayloadDisplay
-            payloadAndType={payloadAndType}
-            tab="chat"
-            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
-          />
+          <PayloadDisplay payloadAndType={payloadAndType} tab="chat" />
         )}
       </div>
       {item.claimable &&

--- a/client/src/payloadDisplay.tsx
+++ b/client/src/payloadDisplay.tsx
@@ -13,14 +13,12 @@ interface PayloadDisplayProps {
   payloadAndType: PayloadAndType;
   clearPayloadToBeSent?: () => void;
   tab?: Tab;
-  scrollToBottomIfApplicable?: () => void;
 }
 
 export const PayloadDisplay = ({
   payloadAndType,
   clearPayloadToBeSent,
   tab,
-  scrollToBottomIfApplicable,
 }: PayloadDisplayProps) => {
   const { payload } = payloadAndType;
   const sendTelemetryEvent = useContext(TelemetryContext);
@@ -74,15 +72,11 @@ export const PayloadDisplay = ({
           <GridStaticImageDisplay
             type={payloadAndType.type}
             payload={payloadAndType.payload}
-            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
           />
         )}
 
         {payloadAndType.type === "grid-search" && (
-          <GridDynamicSearchDisplay
-            payload={payloadAndType.payload}
-            scrollToBottomIfApplicable={scrollToBottomIfApplicable}
-          />
+          <GridDynamicSearchDisplay payload={payloadAndType.payload} />
         )}
 
         {clearPayloadToBeSent && (


### PR DESCRIPTION
Despite efforts in https://github.com/guardian/pinboard/pull/169 there were still occasions where it layout shift in the items in scrollable area would mean we weren't quite scrolled to the bottom, so now as soon as we have content in the scrollable area we register a [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to listen for changes in height of the scrollable content (i.e. all the `ItemDisplays`) and if we do the previous `scrollToBottomIfApplicable` behaviour (i.e. if we're currently scrolled to bottom then keep it that way by scrolling to the bottom, e.g. new message comes in or one of the `GridDynamicSearchDisplay` reloads).

This means we could phase out passing the `scrollToBottomIfApplicable` function around, thereby simplifying some of the child components 🎉 