### PR TITLE
attempt to `focus` relevant browser tab when clicking a desktop/push notification

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -267,24 +267,32 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
 
   const showDesktopNotification = (item?: Item) => {
     if (item && item.userEmail !== userEmail) {
-      serviceWorkerIFrameRef.current?.contentWindow?.postMessage(
-        {
-          item: {
-            ...item,
-            payload: item.payload && JSON.parse(item.payload),
-          } as ItemWithParsedPayload,
-        },
-        desktopNotificationsPreferencesUrl
+      setTimeout(
+        () =>
+          serviceWorkerIFrameRef.current?.contentWindow?.postMessage(
+            {
+              item: {
+                ...item,
+                payload: item.payload && JSON.parse(item.payload),
+              } as ItemWithParsedPayload,
+            },
+            "*"
+          ),
+        500
       );
     }
   };
 
   const clearDesktopNotificationsForPinboardId = (pinboardId: string) => {
-    serviceWorkerIFrameRef.current?.contentWindow?.postMessage(
-      {
-        clearNotificationsForPinboardId: pinboardId,
-      },
-      desktopNotificationsPreferencesUrl
+    setTimeout(
+      () =>
+        serviceWorkerIFrameRef.current?.contentWindow?.postMessage(
+          {
+            clearNotificationsForPinboardId: pinboardId,
+          },
+          "*"
+        ),
+      1000
     );
   };
 

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -336,53 +336,53 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
   return (
     <TelemetryContext.Provider value={sendTelemetryEvent}>
       <ApolloProvider client={apolloClient}>
-        <Global styles={agateFontFaceIfApplicable} />
-        <HiddenIFrameForServiceWorker iFrameRef={serviceWorkerIFrameRef} />
-        <root.div
-          onDragOver={(event) =>
-            isGridDragEvent(event) && event.preventDefault()
+        <GlobalStateProvider
+          presetUnreadNotificationCount={presetUnreadNotificationCount}
+          userEmail={userEmail}
+          openPinboardIdBasedOnQueryParam={openPinboardIdBasedOnQueryParam}
+          preselectedComposerId={preSelectedComposerId}
+          payloadToBeSent={payloadToBeSent}
+          clearPayloadToBeSent={clearPayloadToBeSent}
+          isExpanded={isExpanded}
+          setIsExpanded={setIsExpanded}
+          userLookup={userLookup}
+          addEmailsToLookup={addEmailsToLookup}
+          hasWebPushSubscription={hasWebPushSubscription}
+          manuallyOpenedPinboardIds={manuallyOpenedPinboardIds || []}
+          setManuallyOpenedPinboardIds={setManuallyOpenedPinboardIds}
+          showNotification={showDesktopNotification}
+          clearDesktopNotificationsForPinboardId={
+            clearDesktopNotificationsForPinboardId
           }
-          onDragEnter={(event) => {
-            if (isGridDragEvent(event)) {
-              event.preventDefault();
-              setIsDropTarget(true);
-            }
-          }}
-          onDragLeave={() => setIsDropTarget(false)}
-          onDragEnd={() => setIsDropTarget(false)}
-          onDragExit={() => setIsDropTarget(false)}
-          onDrop={(event) => {
-            if (isGridDragEvent(event)) {
-              event.preventDefault();
-              const payload = convertGridDragEventToPayload(event);
-              setPayloadToBeSent(payload);
-              setIsExpanded(true);
-              payload &&
-                sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.DRAG_AND_DROP, {
-                  assetType: payload.type,
-                });
-            }
-            setIsDropTarget(false);
-          }}
         >
-          <GlobalStateProvider
-            presetUnreadNotificationCount={presetUnreadNotificationCount}
-            userEmail={userEmail}
-            openPinboardIdBasedOnQueryParam={openPinboardIdBasedOnQueryParam}
-            preselectedComposerId={preSelectedComposerId}
-            payloadToBeSent={payloadToBeSent}
-            clearPayloadToBeSent={clearPayloadToBeSent}
-            isExpanded={isExpanded}
-            setIsExpanded={setIsExpanded}
-            userLookup={userLookup}
-            addEmailsToLookup={addEmailsToLookup}
-            hasWebPushSubscription={hasWebPushSubscription}
-            manuallyOpenedPinboardIds={manuallyOpenedPinboardIds || []}
-            setManuallyOpenedPinboardIds={setManuallyOpenedPinboardIds}
-            showNotification={showDesktopNotification}
-            clearDesktopNotificationsForPinboardId={
-              clearDesktopNotificationsForPinboardId
+          <Global styles={agateFontFaceIfApplicable} />
+          <HiddenIFrameForServiceWorker iFrameRef={serviceWorkerIFrameRef} />
+          <root.div
+            onDragOver={(event) =>
+              isGridDragEvent(event) && event.preventDefault()
             }
+            onDragEnter={(event) => {
+              if (isGridDragEvent(event)) {
+                event.preventDefault();
+                setIsDropTarget(true);
+              }
+            }}
+            onDragLeave={() => setIsDropTarget(false)}
+            onDragEnd={() => setIsDropTarget(false)}
+            onDragExit={() => setIsDropTarget(false)}
+            onDrop={(event) => {
+              if (isGridDragEvent(event)) {
+                event.preventDefault();
+                const payload = convertGridDragEventToPayload(event);
+                setPayloadToBeSent(payload);
+                setIsExpanded(true);
+                payload &&
+                  sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.DRAG_AND_DROP, {
+                    assetType: payload.type,
+                  });
+              }
+              setIsDropTarget(false);
+            }}
           >
             <TickContext.Provider value={lastTickTimestamp}>
               {isInlineMode ? (
@@ -396,16 +396,16 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
                 </React.Fragment>
               )}
             </TickContext.Provider>
-          </GlobalStateProvider>
-        </root.div>
-        {assetHandles.map((node, index) => (
-          <AddToPinboardButtonPortal
-            key={index}
-            node={node}
-            setPayloadToBeSent={setPayloadToBeSent}
-            expand={expandFloaty}
-          />
-        ))}
+          </root.div>
+          {assetHandles.map((node, index) => (
+            <AddToPinboardButtonPortal
+              key={index}
+              node={node}
+              setPayloadToBeSent={setPayloadToBeSent}
+              expand={expandFloaty}
+            />
+          ))}
+        </GlobalStateProvider>
       </ApolloProvider>
     </TelemetryContext.Provider>
   );

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -384,15 +384,17 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   useEffect(() => {
     window.addEventListener("message", (event) => {
-      if (
-        event.source !== window &&
-        Object.prototype.hasOwnProperty.call(event.data, "item")
-      ) {
-        const item = event.data.item;
+      if (Object.prototype.hasOwnProperty.call(event.data, "item")) {
+        const item: Item = event.data.item;
         window.focus();
         setIsExpanded(true);
-        setSelectedPinboardId(item.pinboardId); // FIXME handle if said pinboard is not active (i.e. load data)
-        // TODO ideally highlight the item
+        if (
+          !preselectedPinboardId ||
+          preselectedPinboardId === item.pinboardId
+        ) {
+          setSelectedPinboardId(item.pinboardId); // FIXME handle if said pinboard is not active (i.e. load data)
+          // highlighting the item is handled in ScrollableItems component
+        }
       }
     });
   }, []);

--- a/client/src/push-notifications/serviceWorker.ts
+++ b/client/src/push-notifications/serviceWorker.ts
@@ -94,13 +94,14 @@ self.addEventListener("notificationclick", (event: any) => {
           const client =
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             clients.find((_: any) => _.id === item.clientId) || clients[0];
-          client.postMessage({
-            item,
-          });
+          console.log(
+            "Pinboard push notification click, attempting to focus client"
+          );
+          return client.focus();
         } else if (event.action === "grid") {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          self.clients.openWindow(
+          return self.clients.openWindow(
             `https://media.${toolsDomain}/search?${openToPinboardQueryParam}&${openToPinboardItemIdQueryParam}`.replace(
               ".code.",
               ".test."
@@ -113,10 +114,11 @@ self.addEventListener("notificationclick", (event: any) => {
         ) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          self.clients.openWindow(
+          return self.clients.openWindow(
             `https://workflow.${toolsDomain}/redirect/${item.pinboardId}?${EXPAND_PINBOARD_QUERY_PARAM}=true&${openToPinboardItemIdQueryParam}`
           );
         }
+        return Promise.resolve();
       })
   );
 });

--- a/client/src/push-notifications/serviceWorker.ts
+++ b/client/src/push-notifications/serviceWorker.ts
@@ -88,12 +88,17 @@ self.addEventListener("notificationclick", (event: any) => {
       .matchAll({
         includeUncontrolled: true,
       })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then((clients: any[]) => {
+      .then((clients: WindowClient[]) => {
         if (!event.action && clients.length > 0) {
           const client =
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            clients.find((_: any) => _.id === item.clientId) || clients[0];
+            clients.find(
+              (client: WindowClient) =>
+                client.id === item.clientId ||
+                client.url?.includes(
+                  `?${OPEN_PINBOARD_QUERY_PARAM}=${item.pinboardId}`
+                )
+            ) || clients[0];
+          client.postMessage({ item }); // send this item to the client, so ideally it can highlight the message from the notification
           console.log(
             "Pinboard push notification click, attempting to focus client"
           );

--- a/client/src/pushNotificationPreferences.tsx
+++ b/client/src/pushNotificationPreferences.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from "react";
 import { agateSans } from "../fontNormaliser";
 import { TelemetryContext, PINBOARD_TELEMETRY_TYPE } from "./types/Telemetry";
+import { useGlobalStateContext } from "./globalState";
+import { OPEN_PINBOARD_QUERY_PARAM } from "../../shared/constants";
+import { isPinboardData } from "../../shared/graphql/extraTypes";
 interface PushNotificationPreferencesOpenerProps {
   hasWebPushSubscription: boolean | null | undefined;
 }
@@ -50,10 +53,20 @@ interface HiddenIFrameForServiceWorkerProps {
 
 export const HiddenIFrameForServiceWorker = ({
   iFrameRef,
-}: HiddenIFrameForServiceWorkerProps) => (
-  <iframe
-    ref={iFrameRef}
-    src={desktopNotificationsPreferencesUrl}
-    style={{ display: "none" }}
-  />
-);
+}: HiddenIFrameForServiceWorkerProps) => {
+  const { selectedPinboardId, preselectedPinboard } = useGlobalStateContext();
+  const maybePinboardId = isPinboardData(preselectedPinboard)
+    ? preselectedPinboard.id
+    : selectedPinboardId;
+  return (
+    <iframe
+      ref={iFrameRef}
+      src={`${desktopNotificationsPreferencesUrl}${
+        maybePinboardId
+          ? `?${OPEN_PINBOARD_QUERY_PARAM}=${maybePinboardId}`
+          : ""
+      }`}
+      style={{ display: "none" }}
+    />
+  );
+};

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -221,13 +221,27 @@ export const ScrollableItems = ({
       const queryParams = new URLSearchParams(window.location.search);
       const itemIdToScrollTo = queryParams.get(PINBOARD_ITEM_ID_QUERY_PARAM);
       if (itemIdToScrollTo && refMap.current[itemIdToScrollTo]) {
-        setTimeout(() => scrollToItem(itemIdToScrollTo), 250);
+        setTimeout(() => scrollToItem(itemIdToScrollTo), 350);
         setHasProcessedItemIdInURL(true);
       }
     } else {
       setHasProcessedItemIdInURL(true);
     }
   });
+
+  useEffect(() => {
+    const handleItemFromServiceWorker = (event: MessageEvent) => {
+      if (Object.prototype.hasOwnProperty.call(event.data, "item")) {
+        const item: Item = event.data.item;
+        if (pinboardId === item.pinboardId) {
+          setTimeout(() => scrollToItem(item.id), 250);
+        }
+      }
+    };
+    window.addEventListener("message", handleItemFromServiceWorker);
+    return () =>
+      window.removeEventListener("message", handleItemFromServiceWorker);
+  }, []);
 
   return (
     <div

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -206,12 +206,15 @@ export const ScrollableItems = ({
   const setRef = (itemID: string) => (node: HTMLDivElement) => {
     refMap.current[itemID] = node;
   };
-  const scrollToItem = (itemID: string) => {
-    const targetElement = refMap.current[itemID];
-    targetElement?.scrollIntoView({ behavior: "smooth" });
-    targetElement.style.animation = "highlight-item 0.5s linear infinite"; // see panel.tsx for definition of 'highlight-item' animation
-    setTimeout(() => (targetElement.style.animation = ""), 2500);
-  };
+  const scrollToItem = useCallback(
+    (itemID: string) => {
+      const targetElement = refMap.current[itemID];
+      targetElement?.scrollIntoView({ behavior: "smooth" });
+      targetElement.style.animation = "highlight-item 0.5s linear infinite"; // see panel.tsx for definition of 'highlight-item' animation
+      setTimeout(() => (targetElement.style.animation = ""), 2500);
+    },
+    [refMap.current]
+  );
 
   useLayoutEffect(() => {
     if (
@@ -221,11 +224,15 @@ export const ScrollableItems = ({
       const queryParams = new URLSearchParams(window.location.search);
       const itemIdToScrollTo = queryParams.get(PINBOARD_ITEM_ID_QUERY_PARAM);
       if (itemIdToScrollTo && refMap.current[itemIdToScrollTo]) {
-        setTimeout(() => scrollToItem(itemIdToScrollTo), 350);
+        setIsScrolledToBottom(false);
+        setTimeout(() => {
+          console.log("scrolling to item with id", itemIdToScrollTo);
+          scrollToItem(itemIdToScrollTo);
+        }, 1000);
+        setHasProcessedItemIdInURL(true);
+      } else if (Object.keys(refMap.current).length > 0) {
         setHasProcessedItemIdInURL(true);
       }
-    } else {
-      setHasProcessedItemIdInURL(true);
     }
   });
 
@@ -278,6 +285,7 @@ export const ScrollableItems = ({
               item.claimedByEmail,
               userLookup,
               lastItemSeenByUsersForItemIDLookup,
+              scrollToItem,
             ]
           )
         )}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,10 @@
       "@types/jest",
       "@types/webpack-env"
     ],
-    "lib": ["esnext", "dom"]
+    "lib": [
+      "esnext",
+      "dom",
+      "webworker"
+    ]
   }
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -11,6 +11,7 @@ export const NOTIFICATIONS_LAMBDA_BASENAME = "pinboard-notifications-lambda";
 export const getNotificationsLambdaFunctionName = (stage: Stage) =>
   `${NOTIFICATIONS_LAMBDA_BASENAME}-${stage}`;
 
+// FIXME we should probably 'eat' these query params once used (using `history.replaceState`)
 export const OPEN_PINBOARD_QUERY_PARAM = "pinboardId";
 export const PINBOARD_ITEM_ID_QUERY_PARAM = "pinboardItemId";
 export const EXPAND_PINBOARD_QUERY_PARAM = "expandPinboard";


### PR DESCRIPTION
_For more information about notifications mechanism see https://github.com/guardian/pinboard/tree/main/notifications-lambda#notifications-lambda_

When experimenting in `CODE` users noticed that clicking a desktop notification when pinboard was open in a non-active tab did not bring the tab to the foreground. This PR looks to address that by calling [`WindowClient.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient/focus) in the service worker.

With multiple tabs open which have pinboard loaded, the notification click needs to focus the correct tab ideally. So now, the hidden iFrame (which facilitates cross-domain communication between the pinboard running in the host application and the service worker running on the pinboard domain) receives the selected pinboard id via a query param, which allows the service worker to know which `WindowClient` to focus.

![notification_highlight](https://user-images.githubusercontent.com/19289579/207601276-f39f2459-2f1c-44d2-a608-d48e2311d16c.gif)
