### PR TITLE
fix auth issues

### DIFF
--- a/auth-lambda/src/index.ts
+++ b/auth-lambda/src/index.ts
@@ -21,9 +21,9 @@ exports.handler = async ({
 
   const maybeAuthedUserEmail =
     authorizationToken &&
-    (await jwtVerify(authorizationToken, publicKey)).payload["userEmail"];
+    (await jwtVerify(authorizationToken, publicKey).catch(console.warn))
+      ?.payload["userEmail"];
 
-  // TODO is this sufficient? (does this expire after 1h or 90d)
   if (maybeAuthedUserEmail) {
     return {
       isAuthorized: true,

--- a/auth-lambda/src/index.ts
+++ b/auth-lambda/src/index.ts
@@ -7,12 +7,7 @@ import { AppSyncAuthorizerEvent } from "aws-lambda";
 
 const S3 = new AWS.S3(standardAwsConfig);
 
-exports.handler = async ({
-  authorizationToken,
-  requestContext,
-}: AppSyncAuthorizerEvent) => {
-  console.log(requestContext);
-
+exports.handler = async ({ authorizationToken }: AppSyncAuthorizerEvent) => {
   const pandaConfig = await getPandaConfig<{ publicKey: string }>(S3);
 
   const publicKey = crypto.createPublicKey(

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -119,6 +119,7 @@ export function mount({
   };
 
   const apolloErrorLink = onError(({ graphQLErrors, networkError }) => {
+    // TODO set some global state which triggers the error overlay
     graphQLErrors?.forEach(({ message, ...gqlError }) => {
       console.error(
         `[Apollo - GraphQL error]: Message: ${message}, Location: ${gqlError.locations}, Path: ${gqlError.path}`


### PR DESCRIPTION
In `auth-lambda` we weren't catching errors from the `jwtVerify` call (typically JWT expiry) and as such the auth-lambda was erroring rather than returning `{ isAuthorized: false }` and so AppSync was returning 500s to the client, and as such the client was not giving up on polling but instead retrying the call on every poll (there are numerous polling things in pinboard client). The client was then reporting these errors to Sentry (twice for each I think), which was exhausting our org wide quota, amongst other negative consequences.

The fix was to catch these errors and `console.warn` instead, and return `{ isAuthorized: false }` as it should. The client behaviour when not authorised is to give up polling (the desired behaviour).

This fix has worked nicely in CODE...
![image](https://user-images.githubusercontent.com/19289579/207328676-0bfdad89-33e6-4aa4-b82d-17b09d91d8cd.png)
