### PR TITLE
fix `userDisplayName` on `ClaimableItem`

### DIFF
--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -207,7 +207,7 @@ export const ItemDisplay = ({
               }
             />
           ),
-          [maybeClaimedBy]
+          [maybeClaimedBy, userDisplayName]
         )}
       {seenBy && <SeenBy seenBy={seenBy} userLookup={userLookup} />}
     </div>


### PR DESCRIPTION
Noticed that `ClaimableItem` component was not rendering a the user name in a friendly way, e.g. 
![image](https://user-images.githubusercontent.com/19289579/207368345-cae11d69-3cd2-479d-8193-85717553af94.png)
(notice the email address instead of first name and last name).

This was because `ClaimableItem` was wrapped in a `useMemo` (for improved performance) which didn't have the `userDisplayName` in its dependencies list and since `userLookup` (from which `userDisplayName` is derived) is populated asynchronously, it never got updated and so displayed the fallback (which is the email address).

**This PR ensures the `userDisplayName` actually flows into `ClaimableItem` when its updated asynchronously.**
