### PR TITLE
catch auth failures and prevent further requests (rather than spamming Sentry)

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -2,36 +2,36 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import root from "react-shadow/emotion";
 import { PayloadAndType } from "./types/PayloadAndType";
 import {
-  ASSET_HANDLE_HTML_TAG,
   AddToPinboardButtonPortal,
+  ASSET_HANDLE_HTML_TAG,
 } from "./addToPinboardButton";
 import {
   ApolloClient,
   ApolloProvider,
+  ReactiveVar,
   useMutation,
   useQuery,
+  useReactiveVar,
   useSubscription,
 } from "@apollo/client";
 import {
   gqlGetMyUser,
+  gqlGetUsers,
   gqlOnManuallyOpenedPinboardIdsChanged,
   gqlSetWebPushSubscriptionForUser,
 } from "../gql";
 import { Item, MyUser, User } from "../../shared/graphql/graphql";
 import { ItemWithParsedPayload } from "./types/ItemWithParsedPayload";
-import {
-  desktopNotificationsPreferencesUrl,
-  HiddenIFrameForServiceWorker,
-} from "./pushNotificationPreferences";
+import { HiddenIFrameForServiceWorker } from "./pushNotificationPreferences";
 import { GlobalStateProvider } from "./globalState";
 import { Floaty } from "./floaty";
 import { Panel } from "./panel";
 import { convertGridDragEventToPayload, isGridDragEvent } from "./drop";
 import { TickContext } from "./formattedDateTime";
 import {
-  TelemetryContext,
-  PINBOARD_TELEMETRY_TYPE,
   IPinboardEventTags,
+  PINBOARD_TELEMETRY_TYPE,
+  TelemetryContext,
 } from "./types/Telemetry";
 import { IUserTelemetryEvent } from "@guardian/user-telemetry-client";
 import {
@@ -39,7 +39,6 @@ import {
   OPEN_PINBOARD_QUERY_PARAM,
 } from "../../shared/constants";
 import { UserLookup } from "./types/UserLookup";
-import { gqlGetUsers } from "../gql";
 import {
   InlineMode,
   WORKFLOW_PINBOARD_ELEMENTS_QUERY_SELECTOR,
@@ -52,10 +51,15 @@ const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
 
 interface PinBoardAppProps {
   apolloClient: ApolloClient<Record<string, unknown>>;
+  hasApolloAuthErrorVar: ReactiveVar<boolean>;
   userEmail: string;
 }
 
-export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
+export const PinBoardApp = ({
+  apolloClient,
+  hasApolloAuthErrorVar,
+  userEmail,
+}: PinBoardAppProps) => {
   const isInlineMode = useMemo(
     () => window.location.hostname.startsWith("workflow."),
     []
@@ -341,10 +345,13 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
 
   const agateFontFaceIfApplicable = useMemo(getAgateFontFaceIfApplicable, []);
 
+  const hasApolloAuthError = useReactiveVar(hasApolloAuthErrorVar);
+
   return (
     <TelemetryContext.Provider value={sendTelemetryEvent}>
       <ApolloProvider client={apolloClient}>
         <GlobalStateProvider
+          hasApolloAuthError={hasApolloAuthError}
           presetUnreadNotificationCount={presetUnreadNotificationCount}
           userEmail={userEmail}
           openPinboardIdBasedOnQueryParam={openPinboardIdBasedOnQueryParam}

--- a/client/src/errorOverlay.tsx
+++ b/client/src/errorOverlay.tsx
@@ -1,0 +1,67 @@
+import { css } from "@emotion/react";
+import { palette, space } from "@guardian/source-foundations";
+import { bottom, floatySize, panelCornerSize, right } from "./styling";
+import { composer } from "../colours";
+import { agateSans } from "../fontNormaliser";
+import { SvgAlertTriangle } from "@guardian/source-react-components";
+import React from "react";
+
+export const ErrorOverlay = () => (
+  <div
+    css={css`
+      position: absolute;
+      top: 32px;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 98;
+      border-top-left-radius: ${space[1]}px;
+      border-top-right-radius: ${space[1]}px;
+      background-color: rgba(255, 255, 255, 0.35);
+      &::after {
+        content: "";
+        position: fixed;
+        background: rgba(255, 255, 255, 0.35);
+        width: ${panelCornerSize}px;
+        height: ${panelCornerSize}px;
+        bottom: ${bottom + floatySize + space[2]}px;
+        right: ${right + floatySize / 2}px;
+        border-bottom-left-radius: ${panelCornerSize}px;
+      }
+    `}
+  >
+    <div
+      css={css`
+        background-color: ${composer.warning[100]};
+        color: ${palette.neutral[100]};
+        ${agateSans.xsmall({ lineHeight: "tight", fontWeight: "bold" })}
+        padding: ${space[2]}px;
+        border-radius: ${space[1]}px;
+        margin: ${space[2]}px;
+        position: relative;
+        top: 0;
+        z-index: 99;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          column-gap: ${space[2]}px;
+        `}
+      >
+        <div
+          css={css`
+            fill: ${palette.neutral[100]};
+          `}
+        >
+          <SvgAlertTriangle size="small" />
+        </div>
+        <div>
+          There has been an error. You may need to refresh the page to allow
+          pinboard to reconnect. Make sure to save your work first!
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -98,6 +98,7 @@ export const useGlobalStateContext = (): GlobalStateContextShape => {
 };
 
 interface GlobalStateProviderProps {
+  hasApolloAuthError: boolean;
   userEmail: string;
   openPinboardIdBasedOnQueryParam: string | null;
   preselectedComposerId: string | null | undefined;
@@ -115,6 +116,7 @@ interface GlobalStateProviderProps {
   presetUnreadNotificationCount: number | undefined;
 }
 export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
+  hasApolloAuthError,
   userEmail,
   openPinboardIdBasedOnQueryParam,
   preselectedComposerId,
@@ -326,6 +328,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     setErrors((prevErrors) => ({ ...prevErrors, [pinboardId]: error }));
 
   const hasError =
+    hasApolloAuthError ||
     Object.entries(errors).find(
       ([pinboardId, error]) => activePinboardIds.includes(pinboardId) && error
     ) !== undefined;

--- a/client/src/inline/inlineModePanel.tsx
+++ b/client/src/inline/inlineModePanel.tsx
@@ -8,6 +8,7 @@ import { useGlobalStateContext } from "../globalState";
 import { getTooltipText } from "../util";
 import root from "react-shadow/emotion";
 import { neutral } from "@guardian/source-foundations";
+import { ErrorOverlay } from "../errorOverlay";
 
 export const INLINE_PANEL_WIDTH = 260;
 
@@ -24,7 +25,7 @@ export const InlineModePanel = ({
   workingTitle,
   headline,
 }: InlineModePanelProps) => {
-  const { activeTab, setActiveTab } = useGlobalStateContext();
+  const { hasError, activeTab, setActiveTab } = useGlobalStateContext();
 
   const panelRef = useRef(null);
 
@@ -64,8 +65,10 @@ export const InlineModePanel = ({
           min-height: 100%;
           max-height: 100%;
           border-radius: 6px;
+          position: relative;
         `}
       >
+        {hasError && <ErrorOverlay />}
         <Global styles={highlightItemsKeyFramesCSS} />
         <Navigation
           activeTab={activeTab}

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -24,6 +24,7 @@ import {
   PinboardData,
   PinboardDataWithClaimCounts,
 } from "../../shared/graphql/extraTypes";
+import { ErrorOverlay } from "./errorOverlay";
 
 const teamPinboardsSortFunction = (
   a: PinboardIdWithClaimCounts,
@@ -44,6 +45,7 @@ const teamPinboardsSortFunction = (
 export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const {
+    hasError,
     isExpanded,
     activePinboards,
     activePinboardIds,
@@ -217,6 +219,7 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
           }px, 50px, 50px, -25px); // clip off the top of the shadow FIXME make relative
       `}
       />
+      {hasError && <ErrorOverlay />}
       {isDropTarget && <div css={{ ...dropTargetCss }} />}
       <Navigation
         activeTab={activeTab}

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -18,11 +18,6 @@ import {
 import { SendMessageArea } from "./sendMessageArea";
 import { useGlobalStateContext } from "./globalState";
 import { css } from "@emotion/react";
-import { palette, space } from "@guardian/source-foundations";
-import { composer } from "../colours";
-import { SvgAlertTriangle } from "@guardian/source-react-components";
-import { agateSans } from "../fontNormaliser";
-import { bottom, floatySize, panelCornerSize, right } from "./styling";
 import { AssetView } from "./assetView";
 import { Feedback } from "./feedback";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
@@ -272,65 +267,6 @@ export const Pinboard: React.FC<PinboardProps> = ({
     <React.Fragment>
       <Feedback />
       {initialItemsQuery.loading && "Loading..."}
-      {hasError && (
-        <div
-          css={css`
-            position: absolute;
-            top: 58px;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            z-index: 98;
-            border-top-left-radius: ${space[1]}px;
-            border-top-right-radius: ${space[1]}px;
-            background-color: rgba(255, 255, 255, 0.35);
-            &::after {
-              content: "";
-              position: fixed;
-              background: rgba(255, 255, 255, 0.35);
-              width: ${panelCornerSize}px;
-              height: ${panelCornerSize}px;
-              bottom: ${bottom + floatySize + space[2]}px;
-              right: ${right + floatySize / 2}px;
-              border-bottom-left-radius: ${panelCornerSize}px;
-            }
-          `}
-        >
-          <div
-            css={css`
-              background-color: ${composer.warning[100]};
-              color: ${palette.neutral[100]};
-              ${agateSans.xsmall({ lineHeight: "tight", fontWeight: "bold" })}
-              padding: ${space[2]}px;
-              border-radius: ${space[1]}px;
-              margin: ${space[2]}px;
-              position: relative;
-              top: 0;
-              z-index: 99;
-            `}
-          >
-            <div
-              css={css`
-                display: flex;
-                align-items: center;
-                column-gap: ${space[2]}px;
-              `}
-            >
-              <div
-                css={css`
-                  fill: ${palette.neutral[100]};
-                `}
-              >
-                <SvgAlertTriangle size="small" />
-              </div>
-              <div>
-                There has been an error. You may need to refresh the page to
-                allow pinboard to reconnect. Make sure to save your work first!
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
       <div // push chat messages to bottom of panel if they do not fill
         css={css`
           flex-grow: 1;


### PR DESCRIPTION
In https://github.com/guardian/pinboard/pull/224 we fixed `auth-lambda` from erroring on expired tokens (typically from polling in stale browser tabs) and at that time the Sentry quota was exhausted so we missed the fact that the client will still report this same volume of failures but now `401`s rather than `500`s essentially.

This PR catches auth failures and sets some global state, which is used to **swallow subsequent requests** and also to present the existing error overlay (although refactored into its own component) but now not just within each `Pinboard` but at the `Panel` and `InlineModePanel` level (also ensuring it displays correctly and doesn't burst out of its container).
