### PR TITLE
Added new grafana hostname to CORS options to allow requests from grafana to bootstrapping server

### DIFF
--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -32,6 +32,7 @@ const server = express();
 const allowList = [
   "https://grafana.local.dev-gutools.co.uk",
   "https://metrics.gutools.co.uk",
+  "https://public.metrics.gutools.co.uk",
 ];
 
 const corsOptions: cors.CorsOptions = {


### PR DESCRIPTION
## What does this change?

Adds new Grafana host to CORS options

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Should be able to make cross origin call from grafana to bootstrapping server

