### PR TITLE
Updated grafana request to include custom date per target. - DO NOT MERGE - Awaiting Grafana update

### DIFF
--- a/bootstrapping-lambda/src/middleware/auth-middleware.test.ts
+++ b/bootstrapping-lambda/src/middleware/auth-middleware.test.ts
@@ -11,6 +11,7 @@ const mockedGetVerifiedUserEmail = mocked(getVerifiedUserEmail, true);
 const mockedUserHasPermission = mocked(userHasPermission, true);
 
 const mockNextFunction = jest.fn();
+const mockSetHeaderFunction = jest.fn();
 
 describe("auth-middleware", () => {
   beforeAll(() => {
@@ -27,9 +28,14 @@ describe("auth-middleware", () => {
       status: jest.fn().mockReturnValue({
         send: jest.fn(),
       }),
+      setHeader: mockSetHeaderFunction,
     } as unknown) as Response;
     await getAuthMiddleware()(mockRequest, mockResponse, mockNextFunction);
     expect(mockResponse.status).toHaveBeenCalledWith(401);
+    expect(mockSetHeaderFunction).toHaveBeenCalledWith(
+      "Access-Control-Allow-Credentials",
+      "true"
+    );
     expect(mockNextFunction).not.toHaveBeenCalled();
   });
 
@@ -42,11 +48,16 @@ describe("auth-middleware", () => {
     const mockResponse = ({
       status: jest.fn(),
       send: jest.fn(),
+      setHeader: mockSetHeaderFunction,
     } as unknown) as Response;
     await getAuthMiddleware(true)(mockRequest, mockResponse, mockNextFunction);
     expect(mockResponse.status).not.toHaveBeenCalled();
     expect(mockResponse.send).toHaveBeenCalledWith(
       "console.error('pan-domain auth cookie missing, invalid or expired')"
+    );
+    expect(mockSetHeaderFunction).toHaveBeenCalledWith(
+      "Access-Control-Allow-Credentials",
+      "true"
     );
     expect(mockNextFunction).not.toHaveBeenCalled();
   });
@@ -62,6 +73,7 @@ describe("auth-middleware", () => {
       status: jest.fn().mockReturnValue({
         send: mockSendFunction,
       }),
+      setHeader: mockSetHeaderFunction,
     } as unknown) as Response;
 
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
@@ -71,6 +83,10 @@ describe("auth-middleware", () => {
     expect(mockResponse.status).toHaveBeenCalledWith(403);
     expect(mockSendFunction).toHaveBeenCalledWith(
       "You do not have permission to use PinBoard"
+    );
+    expect(mockSetHeaderFunction).toHaveBeenCalledWith(
+      "Access-Control-Allow-Credentials",
+      "true"
     );
     expect(mockNextFunction).not.toHaveBeenCalled();
     expect(mockRequest.userEmail).toBeUndefined();
@@ -86,6 +102,7 @@ describe("auth-middleware", () => {
     const mockResponse = ({
       status: jest.fn(),
       send: mockSendFunction,
+      setHeader: mockSetHeaderFunction,
     } as unknown) as Response;
 
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
@@ -95,6 +112,10 @@ describe("auth-middleware", () => {
     expect(mockResponse.status).not.toHaveBeenCalled();
     expect(mockSendFunction).toHaveBeenCalledWith(
       "console.log('You do not have permission to use PinBoard')"
+    );
+    expect(mockSetHeaderFunction).toHaveBeenCalledWith(
+      "Access-Control-Allow-Credentials",
+      "true"
     );
     expect(mockNextFunction).not.toHaveBeenCalled();
     expect(mockRequest.userEmail).toBeUndefined();
@@ -110,12 +131,17 @@ describe("auth-middleware", () => {
       status: jest.fn().mockReturnValue({
         send: jest.fn(),
       }),
+      setHeader: mockSetHeaderFunction,
     } as unknown) as Response;
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
     mockedUserHasPermission.mockResolvedValueOnce(true);
     await getAuthMiddleware()(mockRequest, mockResponse, mockNextFunction);
     expect(mockRequest.userEmail).toBe("foo@bar.com");
     expect(mockResponse.status).not.toHaveBeenCalled();
+    expect(mockSetHeaderFunction).toHaveBeenCalledWith(
+      "Access-Control-Allow-Credentials",
+      "true"
+    );
     expect(mockNextFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/bootstrapping-lambda/src/middleware/auth-middleware.ts
+++ b/bootstrapping-lambda/src/middleware/auth-middleware.ts
@@ -16,6 +16,7 @@ export const getAuthMiddleware = (sendErrorAsOk = false) => async (
   next: NextFunction
 ) => {
   const maybeCookieHeader = request.header("Cookie");
+  response.setHeader("Access-Control-Allow-Credentials", "true");
   const maybeAuthenticatedEmail = await getVerifiedUserEmail(maybeCookieHeader);
 
   if (!maybeAuthenticatedEmail) {

--- a/bootstrapping-lambda/src/reporting/reportingServiceClient.ts
+++ b/bootstrapping-lambda/src/reporting/reportingServiceClient.ts
@@ -14,27 +14,22 @@ const metricEndpointMap: Record<string, Stage> = {
   [StageMetric.UNIQUE_USERS_PROD]: "PROD",
 };
 
-const stageMetricToMetric = {
-  [StageMetric.UNIQUE_USERS_CODE]: Metric.UNIQUE_USERS,
-  [StageMetric.UNIQUE_USERS_PROD]: Metric.UNIQUE_USERS,
-};
-
 export const getMetrics = async (
   request: GrafanaRequest
 ): Promise<MetricsResponse[]> => {
   const lambda = new AWS.Lambda(standardAwsConfig);
   const { range, targets } = request;
   const metricsResponse = await Promise.all(
-    targets.map((target) => {
-      console.log(`processing grafana request`, target.target);
+    targets.map(({ target, data }) => {
+      console.log(`processing grafana request`, target);
       return lambda
         .invoke({
           FunctionName: getDatabaseBridgeLambdaFunctionName(
-            metricEndpointMap[target.target]
+            data?.stage || metricEndpointMap[target]
           ),
           Payload: JSON.stringify({
             range,
-            metric: stageMetricToMetric[target.target],
+            metric: Metric.UNIQUE_USERS,
           }),
         })
         .promise();

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -44,7 +44,6 @@ server.use(express.json());
 server.use(cors(corsOptions));
 
 server.post("/search", getAuthMiddleware(), (_, response) => {
-  response.setHeader("Access-Control-Allow-Credentials", "true");
   return response.json(Object.values(StageMetric));
 });
 
@@ -52,7 +51,6 @@ server.post(
   "/query",
   getAuthMiddleware(),
   async (request: AuthenticatedRequest, response) => {
-    response.setHeader("Access-Control-Allow-Credentials", "true");
     const { body: metricsQuery }: { body: GrafanaRequest } = request;
     response.json(await getMetrics(metricsQuery));
   }

--- a/shared/types/grafanaType.ts
+++ b/shared/types/grafanaType.ts
@@ -1,3 +1,5 @@
+import { Stage } from "./stage";
+
 export interface Range {
   from: string;
   to: string;
@@ -9,15 +11,21 @@ export type TargetType = "timeserie" | "table";
 export enum StageMetric {
   UNIQUE_USERS_CODE = "uniqueUsersCode",
   UNIQUE_USERS_PROD = "uniqueUsersProd",
+  UNIQUE_USERS = "uniqueUsers",
 }
 
 export enum Metric {
   UNIQUE_USERS = "uniqueUsers",
 }
 
+export interface customData {
+  stage?: Stage;
+}
+
 export interface Target {
   target: StageMetric;
   type: TargetType;
+  data?: customData;
 }
 
 export interface GrafanaRequest {


### PR DESCRIPTION
Removed mapping from Stage as no required.
Moved `Access-Control-Allow-Credentials` header setting to middleware Added or logic on optional stage in custom data from grafana request to allow rollout with new and legacy support.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
