### PR TITLE
Explain how to resolve out-of-date graphql mismatches

### DIFF
--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -24,6 +24,7 @@ const allQueries = [...QUERIES.database, ...QUERIES.workflow, ...QUERIES.grid];
 type QueriesDefinedHere = typeof allQueries[number];
 
 // if the below line fails TSC, it means that the list of Queries defined in the schema.graphql doesn't match the list defined in `QUERIES` above
+// run `yarn graphql-refresh` to resolve
 assert<Equals<QueriesFromCodeGen, QueriesDefinedHere>>();
 
 export const MUTATIONS = {


### PR DESCRIPTION
tiny QOL change

## What does this change?

I pulled and ran tests for the first time in a while, and I got the cryptic error message

  Type 'false' does not satisfy the constraint 'true'.

It does give a pointer to the erroring line which has a comment, but it's not immediately clear what needs to be done.
Give the necessary command to save me time when I inevitably do the same thing again 😅
(Ideally I'd include in the error message but I couldn't see how to do that in tsafe)
