### PR TITLE
capture `[Apollo - Network error]` exception properly

### DIFF
--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -159,7 +159,10 @@ export function mount({
       ) {
         hasApolloAuthErrorVar(true);
       } else {
-        pinboardSpecificSentryClient.captureException(networkError);
+        pinboardSpecificSentryClient.captureException(
+          "Apollo - Network error",
+          { data: networkError }
+        );
       }
     }
   });


### PR DESCRIPTION
When we encounter a network error with graphql it was calling `Sentry.captureException` with the network error, but that doesn't fit the shape expected by Sentry, resulting in...
![image](https://user-images.githubusercontent.com/19289579/226587974-6b29beb5-02d0-443c-a0f6-74db03e611d6.png)
... which is hard to debug. So now we send the string `[Apollo - Network error]` and add the network error object to the `data` field.

The volumes of this error are relatively high ([approx. 700 per week](https://the-guardian.sentry.io/issues/?groupStatsPeriod=auto&page=0&project=6237549&query=is%3Aunresolved+%22Non-Error+exception+captured+with+keys%3A+errors%22&referrer=issue-list&sort=freq&statsPeriod=14d)), so once we have better visibility (as a result of this PR) we should probably capture any expected network errors and not report to Sentry, BEFORE we release to all of editorial.