### PR TITLE
upgrade TypeScript to `5.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prompts": "^2.4.2",
     "ts-jest": "^26.5.4",
     "tsafe": "^1.0.1",
-    "typescript": "^4.6.3",
+    "typescript": "^5.0.2",
     "wsrun": "^5.2.4",
     "yarn-deduplicate": "^3.1.0",
     "yarn-run-all": "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11587,10 +11587,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.22"


### PR DESCRIPTION
because...
A) it's best practice 
B) we want to use of nice new features such as `satisfies` keyword (see https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#satisfies) in #237  for example