### PR TITLE
Upgrade `prettier`

### DIFF
--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -108,9 +108,8 @@
       1000 // 1 second delay
     );
 
-    const preSelectPinboardElement = document.createElement(
-      "pinboard-preselect"
-    );
+    const preSelectPinboardElement =
+      document.createElement("pinboard-preselect");
     preSelectPinboardElement.dataset.composerId = "54f2d2fee4b011581586e710";
     document
       .getElementById("btn-add-preselection")
@@ -123,9 +122,8 @@
         preSelectPinboardElement.remove();
       });
 
-    const preSelectInvalidPinboardElement = document.createElement(
-      "pinboard-preselect"
-    );
+    const preSelectInvalidPinboardElement =
+      document.createElement("pinboard-preselect");
     preSelectInvalidPinboardElement.dataset.composerId = "INVALID";
     document
       .getElementById("btn-add-invalid-preselection")

--- a/bootstrapping-lambda/src/middleware/auth-middleware.test.ts
+++ b/bootstrapping-lambda/src/middleware/auth-middleware.test.ts
@@ -18,31 +18,31 @@ describe("auth-middleware", () => {
   });
 
   test("should return a 401 response where no cookie provided", async () => {
-    const mockRequest = ({
+    const mockRequest = {
       header: jest.fn().mockReturnValue(undefined),
       userEmail: undefined,
-    } as unknown) as AuthenticatedRequest;
+    } as unknown as AuthenticatedRequest;
 
-    const mockResponse = ({
+    const mockResponse = {
       status: jest.fn().mockReturnValue({
         send: jest.fn(),
       }),
-    } as unknown) as Response;
+    } as unknown as Response;
     await getAuthMiddleware()(mockRequest, mockResponse, mockNextFunction);
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockNextFunction).not.toHaveBeenCalled();
   });
 
   test("should return a 200 response where no cookie provided and sendErrorAsOk is true", async () => {
-    const mockRequest = ({
+    const mockRequest = {
       header: jest.fn().mockReturnValue(undefined),
       userEmail: undefined,
-    } as unknown) as AuthenticatedRequest;
+    } as unknown as AuthenticatedRequest;
 
-    const mockResponse = ({
+    const mockResponse = {
       status: jest.fn(),
       send: jest.fn(),
-    } as unknown) as Response;
+    } as unknown as Response;
     await getAuthMiddleware(true)(mockRequest, mockResponse, mockNextFunction);
     expect(mockResponse.status).not.toHaveBeenCalled();
     expect(mockResponse.send).toHaveBeenCalledWith(
@@ -52,17 +52,17 @@ describe("auth-middleware", () => {
   });
 
   test("should return a 403 response where user does not have permission", async () => {
-    const mockRequest = ({
+    const mockRequest = {
       header: jest.fn().mockReturnValue({ Cookie: "foo@bar.com" }),
       userEmail: undefined,
-    } as unknown) as AuthenticatedRequest;
+    } as unknown as AuthenticatedRequest;
 
     const mockSendFunction = jest.fn();
-    const mockResponse = ({
+    const mockResponse = {
       status: jest.fn().mockReturnValue({
         send: mockSendFunction,
       }),
-    } as unknown) as Response;
+    } as unknown as Response;
 
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
 
@@ -77,16 +77,16 @@ describe("auth-middleware", () => {
   });
 
   test("should return a 200 response where user does not have permission and sendErrorAsOk is true", async () => {
-    const mockRequest = ({
+    const mockRequest = {
       header: jest.fn().mockReturnValue({ Cookie: "foo@bar.com" }),
       userEmail: undefined,
-    } as unknown) as AuthenticatedRequest;
+    } as unknown as AuthenticatedRequest;
 
     const mockSendFunction = jest.fn();
-    const mockResponse = ({
+    const mockResponse = {
       status: jest.fn(),
       send: mockSendFunction,
-    } as unknown) as Response;
+    } as unknown as Response;
 
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
 
@@ -101,16 +101,16 @@ describe("auth-middleware", () => {
   });
 
   test("calls next where user authenticated & authorised", async () => {
-    const mockRequest = ({
+    const mockRequest = {
       header: jest.fn().mockReturnValue({ Cookie: "foo@bar.com" }),
       userEmail: undefined,
-    } as unknown) as AuthenticatedRequest;
+    } as unknown as AuthenticatedRequest;
 
-    const mockResponse = ({
+    const mockResponse = {
       status: jest.fn().mockReturnValue({
         send: jest.fn(),
       }),
-    } as unknown) as Response;
+    } as unknown as Response;
     mockedGetVerifiedUserEmail.mockResolvedValueOnce("foo@bar.com");
     mockedUserHasPermission.mockResolvedValueOnce(true);
     await getAuthMiddleware()(mockRequest, mockResponse, mockNextFunction);

--- a/bootstrapping-lambda/src/middleware/auth-middleware.ts
+++ b/bootstrapping-lambda/src/middleware/auth-middleware.ts
@@ -10,33 +10,37 @@ export interface AuthenticatedRequest extends Request {
   userEmail?: string;
 }
 
-export const getAuthMiddleware = (sendErrorAsOk = false) => async (
-  request: AuthenticatedRequest,
-  response: Response,
-  next: NextFunction
-) => {
-  const maybeCookieHeader = request.header("Cookie");
-  const maybeAuthenticatedEmail = await getVerifiedUserEmail(maybeCookieHeader);
+export const getAuthMiddleware =
+  (sendErrorAsOk = false) =>
+  async (
+    request: AuthenticatedRequest,
+    response: Response,
+    next: NextFunction
+  ) => {
+    const maybeCookieHeader = request.header("Cookie");
+    const maybeAuthenticatedEmail = await getVerifiedUserEmail(
+      maybeCookieHeader
+    );
 
-  if (!maybeAuthenticatedEmail) {
+    if (!maybeAuthenticatedEmail) {
+      return sendErrorAsOk
+        ? response.send(`console.error('${MISSING_AUTH_COOKIE_MESSAGE}')`)
+        : response
+            .status(HTTP_STATUS_CODES.UNAUTHORIZED)
+            .send(MISSING_AUTH_COOKIE_MESSAGE);
+    }
+
+    if (await userHasPermission(maybeAuthenticatedEmail)) {
+      request.userEmail = maybeAuthenticatedEmail;
+      return next();
+    }
+
+    const NO_PINBOARD_PERMISSION_MESSAGE =
+      "You do not have permission to use PinBoard";
+
     return sendErrorAsOk
-      ? response.send(`console.error('${MISSING_AUTH_COOKIE_MESSAGE}')`)
+      ? response.send(`console.log('${NO_PINBOARD_PERMISSION_MESSAGE}')`)
       : response
-          .status(HTTP_STATUS_CODES.UNAUTHORIZED)
-          .send(MISSING_AUTH_COOKIE_MESSAGE);
-  }
-
-  if (await userHasPermission(maybeAuthenticatedEmail)) {
-    request.userEmail = maybeAuthenticatedEmail;
-    return next();
-  }
-
-  const NO_PINBOARD_PERMISSION_MESSAGE =
-    "You do not have permission to use PinBoard";
-
-  return sendErrorAsOk
-    ? response.send(`console.log('${NO_PINBOARD_PERMISSION_MESSAGE}')`)
-    : response
-        .status(HTTP_STATUS_CODES.FORBIDDEN)
-        .send(NO_PINBOARD_PERMISSION_MESSAGE);
-};
+          .status(HTTP_STATUS_CODES.FORBIDDEN)
+          .send(NO_PINBOARD_PERMISSION_MESSAGE);
+  };

--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -104,8 +104,9 @@ server.get(
           filename.endsWith(JS_EXTENSION)
       )
       .reduce((mostRecentSoFar, filename) => {
-        const lastModified = fs.statSync(`${clientDirectory}/${filename}`)
-          .mtime;
+        const lastModified = fs.statSync(
+          `${clientDirectory}/${filename}`
+        ).mtime;
         if (mostRecentSoFar && mostRecentSoFar.lastModified > lastModified) {
           return mostRecentSoFar;
         }

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -430,27 +430,30 @@ export class PinBoardStack extends GuStack {
       }
     );
 
-    const pinboardWorkflowBridgeLambdaDataSource = pinboardAppsyncApi.addLambdaDataSource(
-      `${WORKFLOW_BRIDGE_LAMBDA_BASENAME.replace("pinboard-", "")
-        .split("-")
-        .join("_")}_ds`,
-      pinboardWorkflowBridgeLambda
-    );
+    const pinboardWorkflowBridgeLambdaDataSource =
+      pinboardAppsyncApi.addLambdaDataSource(
+        `${WORKFLOW_BRIDGE_LAMBDA_BASENAME.replace("pinboard-", "")
+          .split("-")
+          .join("_")}_ds`,
+        pinboardWorkflowBridgeLambda
+      );
 
-    const pinboardGridBridgeLambdaDataSource = pinboardAppsyncApi.addLambdaDataSource(
-      `${gridBridgeLambdaBasename
-        .replace("pinboard-", "")
-        .split("-")
-        .join("_")}_ds`,
-      pinboardGridBridgeLambda
-    );
+    const pinboardGridBridgeLambdaDataSource =
+      pinboardAppsyncApi.addLambdaDataSource(
+        `${gridBridgeLambdaBasename
+          .replace("pinboard-", "")
+          .split("-")
+          .join("_")}_ds`,
+        pinboardGridBridgeLambda
+      );
 
-    const pinboardDatabaseBridgeLambdaDataSource = pinboardAppsyncApi.addLambdaDataSource(
-      `${DATABASE_BRIDGE_LAMBDA_BASENAME.replace("pinboard-", "")
-        .split("-")
-        .join("_")}_ds`,
-      pinboardDatabaseBridgeLambda
-    );
+    const pinboardDatabaseBridgeLambdaDataSource =
+      pinboardAppsyncApi.addLambdaDataSource(
+        `${DATABASE_BRIDGE_LAMBDA_BASENAME.replace("pinboard-", "")
+          .split("-")
+          .join("_")}_ds`,
+        pinboardDatabaseBridgeLambda
+      );
 
     const gqlSchemaChecksum = crypto
       .createHash("md5")
@@ -464,18 +467,17 @@ export class PinBoardStack extends GuStack {
         `## schema checksum : ${gqlSchemaChecksum}\n${mappingTemplate.renderTemplate()}`
       );
 
-    const createLambdaResolver = (
-      lambdaDS: appsync.LambdaDataSource,
-      typeName: "Query" | "Mutation"
-    ) => (fieldName: string) => {
-      lambdaDS.createResolver({
-        typeName,
-        fieldName,
-        responseMappingTemplate: resolverBugWorkaround(
-          appsync.MappingTemplate.lambdaResult()
-        ),
-      });
-    };
+    const createLambdaResolver =
+      (lambdaDS: appsync.LambdaDataSource, typeName: "Query" | "Mutation") =>
+      (fieldName: string) => {
+        lambdaDS.createResolver({
+          typeName,
+          fieldName,
+          responseMappingTemplate: resolverBugWorkaround(
+            appsync.MappingTemplate.lambdaResult()
+          ),
+        });
+      };
 
     QUERIES.database.forEach(
       createLambdaResolver(pinboardDatabaseBridgeLambdaDataSource, "Query")
@@ -589,10 +591,11 @@ export class PinBoardStack extends GuStack {
           APP,
           [ENVIRONMENT_VARIABLE_KEYS.graphqlEndpoint]:
             pinboardAppsyncApi.graphqlUrl,
-          [ENVIRONMENT_VARIABLE_KEYS.sentryDSN]: ssm.StringParameter.valueForStringParameter(
-            this,
-            "/pinboard/sentryDSN"
-          ),
+          [ENVIRONMENT_VARIABLE_KEYS.sentryDSN]:
+            ssm.StringParameter.valueForStringParameter(
+              this,
+              "/pinboard/sentryDSN"
+            ),
         },
         functionName: `${bootstrappingLambdaBasename}-${this.stage}`,
         code: lambda.Code.fromBucket(

--- a/client/fontNormaliser.ts
+++ b/client/fontNormaliser.ts
@@ -20,31 +20,31 @@ const agateFontNameVariants = [
 
 // source foundations will give us Guardian Text Sans, but we usually want Guardian Agate Sans, so as to fit in with
 // the tools hosting pinboard.
-const overrideToAgateSans: FontOverride = (
-  originalFunc: FontScaleFunctionStr
-) => (options?: FontScaleArgs) => `
+const overrideToAgateSans: FontOverride =
+  (originalFunc: FontScaleFunctionStr) => (options?: FontScaleArgs) =>
+    `
   ${originalFunc(options)};
   font-family: ${agateFontNameVariants
     .map((_) => `"${_}"`)
     .join(",")}, Arial, sans-serif;
 `;
 
-const defaultToPx: FontOverride = (originalFunc: FontScaleFunctionStr) => (
-  options?: FontScaleArgs
-) => originalFunc({ unit: "px", ...options });
+const defaultToPx: FontOverride =
+  (originalFunc: FontScaleFunctionStr) => (options?: FontScaleArgs) =>
+    originalFunc({ unit: "px", ...options });
 
 type FontDefinition = { [fontSizeName: string]: FontScaleFunctionStr };
 
-const applyFontOverride = <T extends FontDefinition>(
-  fontOverride: FontOverride
-) => (originalFont: T) =>
-  Object.entries(originalFont).reduce(
-    (acc, [fontSizeName, fontScaleFunc]) => ({
-      ...acc,
-      [fontSizeName]: fontOverride(fontScaleFunc),
-    }),
-    {} as T
-  );
+const applyFontOverride =
+  <T extends FontDefinition>(fontOverride: FontOverride) =>
+  (originalFont: T) =>
+    Object.entries(originalFont).reduce(
+      (acc, [fontSizeName, fontScaleFunc]) => ({
+        ...acc,
+        [fontSizeName]: fontOverride(fontScaleFunc),
+      }),
+      {} as T
+    );
 
 const agateSansFont = applyFontOverride(overrideToAgateSans);
 const pixelSizedFont = applyFontOverride(defaultToPx);

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -105,9 +105,8 @@ export const PinBoardApp = ({
     );
 
   const refreshPreselectedPinboard = () => {
-    const preselectPinboardHTMLElement: HTMLElement | null = document.querySelector(
-      PRESELECT_PINBOARD_HTML_TAG
-    );
+    const preselectPinboardHTMLElement: HTMLElement | null =
+      document.querySelector(PRESELECT_PINBOARD_HTML_TAG);
     const newComposerId = preselectPinboardHTMLElement?.dataset?.composerId;
     newComposerId !== preSelectedComposerId &&
       setPreselectedComposerId(newComposerId);
@@ -118,14 +117,14 @@ export const PinBoardApp = ({
       setComposerSection(newComposerSection);
   };
 
-  const [
-    presetUnreadNotificationCount,
-    setPresetUnreadNotificationCount,
-  ] = useState<number | undefined>();
+  const [presetUnreadNotificationCount, setPresetUnreadNotificationCount] =
+    useState<number | undefined>();
   const refreshPresetUnreadNotifications = () => {
-    const rawCount = (document.querySelector(
-      PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG
-    ) as HTMLElement)?.dataset?.count;
+    const rawCount = (
+      document.querySelector(
+        PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG
+      ) as HTMLElement
+    )?.dataset?.count;
 
     if (rawCount !== undefined) {
       const count = parseInt(rawCount);

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -127,7 +127,7 @@ export function mount({
         `[Apollo - GraphQL error]: Message: ${message}, Location: ${gqlError.locations}, Path: ${gqlError.path}`
       );
       if (
-        ((gqlError as unknown) as Record<string, unknown>).errorType ===
+        (gqlError as unknown as Record<string, unknown>).errorType ===
           "UnauthorizedException" ||
         gqlError.extensions?.code === "UNAUTHENTICATED"
       ) {
@@ -149,11 +149,13 @@ export function mount({
       console.error(`[Apollo - Network error]`, networkError);
       if (
         [401, 403].includes(
-          ((networkError as unknown) as { statusCode: number })?.statusCode
+          (networkError as unknown as { statusCode: number })?.statusCode
         ) ||
-        ((networkError as unknown) as {
-          errors: Array<{ message: string }>;
-        })?.errors?.find((error) =>
+        (
+          networkError as unknown as {
+            errors: Array<{ message: string }>;
+          }
+        )?.errors?.find((error) =>
           error.message?.includes("UnauthorizedException")
         )
       ) {

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -342,15 +342,14 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
 
   const [unreadFlags, setUnreadFlags] = useState<PerPinboard<boolean>>({});
 
-  const setUnreadFlag = (pinboardId: string) => (
-    unreadFlag: boolean | undefined
-  ) => {
-    setUnreadFlags((prevUnreadFlags) => ({
-      ...prevUnreadFlags,
-      [pinboardId]: unreadFlag,
-    }));
-    !unreadFlag && clearDesktopNotificationsForPinboardId(pinboardId);
-  };
+  const setUnreadFlag =
+    (pinboardId: string) => (unreadFlag: boolean | undefined) => {
+      setUnreadFlags((prevUnreadFlags) => ({
+        ...prevUnreadFlags,
+        [pinboardId]: unreadFlag,
+      }));
+      !unreadFlag && clearDesktopNotificationsForPinboardId(pinboardId);
+    };
 
   const hasUnread =
     Object.values(unreadFlags).find((unreadFlag) => unreadFlag) || false;
@@ -430,10 +429,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     };
   };
 
-  const [
-    explicitPositionTranslation,
-    setExplicitPositionTranslationState,
-  ] = useState<ControlPosition>({ x: 0, y: 0 });
+  const [explicitPositionTranslation, setExplicitPositionTranslationState] =
+    useState<ControlPosition>({ x: 0, y: 0 });
   const setExplicitPositionTranslation = (newPosition: ControlPosition) => {
     setExplicitPositionTranslationState(newPosition);
     window.localStorage.setItem(
@@ -442,10 +439,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     );
   };
 
-  const [
-    boundedPositionTranslation,
-    setBoundedPositionTranslation,
-  ] = useState<ControlPosition>({ x: 0, y: 0 });
+  const [boundedPositionTranslation, setBoundedPositionTranslation] =
+    useState<ControlPosition>({ x: 0, y: 0 });
   // position translation must be passed in rather than using explicitPositionTranslation to avoid a rerender briefly in the old position
   const updateBoundedPositionTranslation = (
     positionTranslation: ControlPosition

--- a/client/src/grid/gridDynamicSearchDisplay.tsx
+++ b/client/src/grid/gridDynamicSearchDisplay.tsx
@@ -25,10 +25,8 @@ const formatChip = (chip: GridBadgeData) => {
 export const GridDynamicSearchDisplay = ({
   payload,
 }: Pick<DynamicGridPayload, "payload">) => {
-  const [
-    gridSearchSummaryLastChecked,
-    setGridSearchSummaryLastChecked,
-  ] = useState<number>();
+  const [gridSearchSummaryLastChecked, setGridSearchSummaryLastChecked] =
+    useState<number>();
 
   const [getGridSearchSummary, getGridSearchSummaryQuery] = useLazyQuery<{
     getGridSearchSummary: GridSearchSummary;

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -37,9 +37,8 @@ export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
     Record<string, PinboardIdWithItemCounts>
   >({});
 
-  const [fetchItemCounts, { stopPolling, startPolling }] = useLazyQuery(
-    gqlGetItemCounts
-  );
+  const [fetchItemCounts, { stopPolling, startPolling }] =
+    useLazyQuery(gqlGetItemCounts);
 
   useEffect(() => {
     stopPolling();

--- a/client/src/itemHoverMenu.tsx
+++ b/client/src/itemHoverMenu.tsx
@@ -48,9 +48,10 @@ export const ItemHoverMenu = ({
     </React.Fragment>
   );
 
-  useEffect(() => setMaybeDeleteItemModalElement(deleteConfirmModalElement), [
-    deleteConfirmModalElement,
-  ]);
+  useEffect(
+    () => setMaybeDeleteItemModalElement(deleteConfirmModalElement),
+    [deleteConfirmModalElement]
+  );
 
   const [deleteItem] = useMutation(gqlDeleteItem, {
     onError: (error) => {

--- a/client/src/itemInputBox.tsx
+++ b/client/src/itemInputBox.tsx
@@ -138,16 +138,22 @@ export const ItemInputBox = ({
         query: gqlSearchMentionableUsers(token),
         context: { debounceKey: "user-search", debounceTimeout: 250 },
       })
-      .then(({ data: { searchMentionableUsers: { users, groups } } }) => [
-        ...users.map((user: User, index: number) => ({
-          ...user,
-          heading: index === 0 ? "INDIVIDUALS" : undefined,
-        })),
-        ...groups.map((group: Group, index: number) => ({
-          ...group,
-          heading: index === 0 ? "GROUPS" : undefined,
-        })),
-      ]);
+      .then(
+        ({
+          data: {
+            searchMentionableUsers: { users, groups },
+          },
+        }) => [
+          ...users.map((user: User, index: number) => ({
+            ...user,
+            heading: index === 0 ? "INDIVIDUALS" : undefined,
+          })),
+          ...groups.map((group: Group, index: number) => ({
+            ...group,
+            heading: index === 0 ? "GROUPS" : undefined,
+          })),
+        ]
+      );
 
   useEffect(
     () => /* unmount handler */ () => {

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -60,10 +60,8 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const selectedPinboard = activePinboards.find(
     (activePinboard) => activePinboard.id === selectedPinboardId
   );
-  const [
-    maybePeekingAtPinboard,
-    setMaybePeekingAtPinboard,
-  ] = useState<PinboardData | null>(null);
+  const [maybePeekingAtPinboard, setMaybePeekingAtPinboard] =
+    useState<PinboardData | null>(null);
 
   const title = (() => {
     if (selectedPinboard?.isNotFound) {
@@ -136,9 +134,10 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
   const pinboardsWithClaimCounts =
     pinboardDataQuery.data?.getPinboardsByIds
       ?.reduce((acc, pinboardData) => {
-        const maybePinboardIdWithClaimCounts = groupPinboardIdsWithClaimCounts.find(
-          (_) => _.pinboardId === pinboardData.id
-        );
+        const maybePinboardIdWithClaimCounts =
+          groupPinboardIdsWithClaimCounts.find(
+            (_) => _.pinboardId === pinboardData.id
+          );
         return maybePinboardIdWithClaimCounts
           ? [
               ...acc,

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -83,10 +83,8 @@ export const Pinboard: React.FC<PinboardProps> = ({
 
   const claimSubscription = useSubscription(gqlOnClaimItem(pinboardId), {
     onSubscriptionData: ({ subscriptionData }) => {
-      const {
-        updatedItem,
-        newItem,
-      }: Claimed = subscriptionData.data.onClaimItem;
+      const { updatedItem, newItem }: Claimed =
+        subscriptionData.data.onClaimItem;
       addEmailsToLookup([newItem.userEmail]);
       setClaimItems((prevState) => [...prevState, updatedItem, newItem]);
       if (!isExpanded) {
@@ -152,10 +150,8 @@ export const Pinboard: React.FC<PinboardProps> = ({
     }
   );
 
-  const [
-    lastItemSeenByUserLookup,
-    setLastItemSeenByUserLookup,
-  ] = useState<LastItemSeenByUserLookup>({});
+  const [lastItemSeenByUserLookup, setLastItemSeenByUserLookup] =
+    useState<LastItemSeenByUserLookup>({});
 
   useSubscription(gqlOnSeenItem(pinboardId), {
     onSubscriptionData: ({ subscriptionData }) => {
@@ -288,10 +284,8 @@ export const Pinboard: React.FC<PinboardProps> = ({
     }
   }, [maybeEditingItemId]);
 
-  const [
-    maybeDeleteItemModalElement,
-    setMaybeDeleteItemModalElement,
-  ] = useState<JSX.Element | null>(null);
+  const [maybeDeleteItemModalElement, setMaybeDeleteItemModalElement] =
+    useState<JSX.Element | null>(null);
 
   return !isSelected ? null : (
     <React.Fragment>

--- a/client/src/push-notifications/registerServiceWorker.ts
+++ b/client/src/push-notifications/registerServiceWorker.ts
@@ -32,7 +32,8 @@ const parentCallback = (maybeWebPushSubscription?: PushSubscription) => {
       console.log("Pinboard Service Worker running");
       await swRegistration.update();
 
-      const maybePushSubscription = await swRegistration.pushManager.getSubscription();
+      const maybePushSubscription =
+        await swRegistration.pushManager.getSubscription();
 
       if (maybePushSubscription) {
         toggleButton.innerText = "Unsubscribe from Desktop Notifications";
@@ -59,7 +60,8 @@ const parentCallback = (maybeWebPushSubscription?: PushSubscription) => {
     // running in iFrame
     else {
       // unfortunately can't call serviceWorker.register() due to cross-origin service worker prevention
-      const maybeSwRegistration = await navigator.serviceWorker.getRegistration();
+      const maybeSwRegistration =
+        await navigator.serviceWorker.getRegistration();
 
       if (maybeSwRegistration) {
         console.log("Pinboard Service Worker running");

--- a/client/src/push-notifications/serviceWorker.ts
+++ b/client/src/push-notifications/serviceWorker.ts
@@ -42,14 +42,12 @@ const showNotification = (
             {
               action: "grid",
               title: "Open in new Grid tab",
-              icon:
-                "https://media.gutools.co.uk/assets/images/grid-favicon-32.png",
+              icon: "https://media.gutools.co.uk/assets/images/grid-favicon-32.png",
             },
             {
               action: "composer",
               title: "Open in new Composer tab",
-              icon:
-                "https://composer.gutools.co.uk/static/10791/image/images/favicon.ico",
+              icon: "https://composer.gutools.co.uk/static/10791/image/images/favicon.ico",
             },
           ],
         }

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -94,10 +94,8 @@ export const ScrollableItems = ({
     [lastItemSeenByUserLookup]
   );
 
-  const [
-    hasPinboardNeverBeenExpanded,
-    setHasPinboardNeverBeenExpanded,
-  ] = useState(true);
+  const [hasPinboardNeverBeenExpanded, setHasPinboardNeverBeenExpanded] =
+    useState(true);
 
   const [scrollableArea, setScrollableArea] = useState<HTMLDivElement | null>(
     null
@@ -192,10 +190,8 @@ export const ScrollableItems = ({
 
   const onScrollThrottled = useThrottle(onScroll, 250);
 
-  const [
-    itemDisplayContainer,
-    setItemDisplayContainer,
-  ] = useState<HTMLDivElement | null>(null);
+  const [itemDisplayContainer, setItemDisplayContainer] =
+    useState<HTMLDivElement | null>(null);
   const setItemDisplayContainerRef = useCallback(
     (node) => node && setItemDisplayContainer(node),
     []

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -83,14 +83,12 @@ export const SelectPinboard = ({
     ? activePinboards.filter((_) => _.id !== preselectedPinboard.id)
     : activePinboards;
 
-  const [
-    searchPinboards,
-    { data, loading, stopPolling, startPolling },
-  ] = useLazyQuery<{
-    listPinboards: PinboardData[];
-  }>(gqlListPinboards, {
-    context: { debounceKey: gqlListPinboards, debounceTimeout: 500 },
-  });
+  const [searchPinboards, { data, loading, stopPolling, startPolling }] =
+    useLazyQuery<{
+      listPinboards: PinboardData[];
+    }>(gqlListPinboards, {
+      context: { debounceKey: gqlListPinboards, debounceTimeout: 500 },
+    });
 
   useEffect(() => {
     if (isExpanded && searchText) {

--- a/client/src/types/PayloadAndType.ts
+++ b/client/src/types/PayloadAndType.ts
@@ -3,10 +3,10 @@ import * as Sentry from "@sentry/react";
 export const sources = ["grid"] as const;
 export const sourceTypes = ["crop", "original", "search"] as const;
 
-export type Source = typeof sources[number];
+export type Source = (typeof sources)[number];
 export const isSource = (source: unknown): source is Source =>
   sources.includes(source as Source);
-export type SourceType = typeof sourceTypes[number];
+export type SourceType = (typeof sourceTypes)[number];
 export const isSourceType = (sourceType: unknown): sourceType is SourceType =>
   sourceTypes.includes(sourceType as SourceType);
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "husky": "^7.0.0",
     "jest": "^26.6.3",
     "lint-staged": ">=10",
-    "prettier": "2.2.1",
+    "prettier": "^2.8.6",
     "prompts": "^2.4.2",
     "ts-jest": "^26.5.4",
     "tsafe": "^1.0.1",

--- a/shared/awsIntegration.ts
+++ b/shared/awsIntegration.ts
@@ -18,24 +18,23 @@ export const standardAwsConfig = {
 
 const ssm = new AWS.SSM(standardAwsConfig);
 
-const paramStorePromiseGetter = (WithDecryption: boolean) => (
-  nameSuffix: string
-) => {
-  const Name = `/${APP}/${nameSuffix}`;
-  return ssm
-    .getParameter({
-      Name,
-      WithDecryption,
-    })
-    .promise()
-    .then((result) => {
-      const value = result.Parameter?.Value;
-      if (!value) {
-        throw Error(`Could not retrieve parameter value for '${Name}'`);
-      }
-      return value;
-    });
-};
+const paramStorePromiseGetter =
+  (WithDecryption: boolean) => (nameSuffix: string) => {
+    const Name = `/${APP}/${nameSuffix}`;
+    return ssm
+      .getParameter({
+        Name,
+        WithDecryption,
+      })
+      .promise()
+      .then((result) => {
+        const value = result.Parameter?.Value;
+        if (!value) {
+          throw Error(`Could not retrieve parameter value for '${Name}'`);
+        }
+        return value;
+      });
+  };
 
 export const pinboardSecretPromiseGetter = paramStorePromiseGetter(true);
 export const pinboardConfigPromiseGetter = paramStorePromiseGetter(false);

--- a/shared/database/local/runDatabaseSetup.ts
+++ b/shared/database/local/runDatabaseSetup.ts
@@ -27,21 +27,22 @@ const runSetupSqlFile = (sql: Sql, fileName: string) =>
     "create User table": () => runSetupSqlFile(sql, "005-UserTable.sql"),
     "enable Lambda invocation from within RDS DB": () =>
       runSetupSqlFile(sql, "006-EnableLambdaInvocation.sql"),
-    "create/update 'after insert' trigger on Item table (to invoke notifications-lambda if applicable)": async () =>
-      // TODO ideally we could do this with sql.file() but it doesn't seem to work
-      sql.unsafe(
-        readFileSync(
-          "./shared/database/local/setup/007-TriggerNotificationsLambdaAfterItemInsert.sql",
-          "utf8"
-        )
-          .replace(
-            "$notificationLambdaFunctionName",
-            getNotificationsLambdaFunctionName(stage)
+    "create/update 'after insert' trigger on Item table (to invoke notifications-lambda if applicable)":
+      async () =>
+        // TODO ideally we could do this with sql.file() but it doesn't seem to work
+        sql.unsafe(
+          readFileSync(
+            "./shared/database/local/setup/007-TriggerNotificationsLambdaAfterItemInsert.sql",
+            "utf8"
           )
-          .replace("$awsRegion", AWS_REGION)
-          .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
-          .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
-      ),
+            .replace(
+              "$notificationLambdaFunctionName",
+              getNotificationsLambdaFunctionName(stage)
+            )
+            .replace("$awsRegion", AWS_REGION)
+            .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
+            .replace("$triggerName", NOTIFICATIONS_DATABASE_TRIGGER_NAME)
+        ),
     "add googleID column to User table": () =>
       runSetupSqlFile(sql, "008-AddGoogleIDToUserTable.sql"),
     "create Group table": () => runSetupSqlFile(sql, "009-GroupTable.sql"),

--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -21,7 +21,7 @@ export const QUERIES = {
 
 type QueriesFromCodeGen = keyof Required<Omit<Query, "__typename">>;
 const allQueries = [...QUERIES.database, ...QUERIES.workflow, ...QUERIES.grid];
-type QueriesDefinedHere = typeof allQueries[number];
+type QueriesDefinedHere = (typeof allQueries)[number];
 
 // if the below line fails TSC, it means that the list of Queries defined in the schema.graphql doesn't match the list defined in `QUERIES` above
 // run `yarn graphql-refresh` to resolve
@@ -42,10 +42,10 @@ export const MUTATIONS = {
 
 type MutationsFromCodeGen = keyof Required<Omit<Mutation, "__typename">>;
 const allMutations = [...MUTATIONS.database];
-type MutationsDefinedHere = typeof allMutations[number];
+type MutationsDefinedHere = (typeof allMutations)[number];
 
 // if the below line fails TSC, it means that the list of Mutations defined in the schema.graphql doesn't match the list defined in `MUTATIONS` above
 assert<Equals<MutationsFromCodeGen, MutationsDefinedHere>>();
 
 const allDatabaseOperations = [...QUERIES.database, ...MUTATIONS.database];
-export type DatabaseOperation = typeof allDatabaseOperations[number];
+export type DatabaseOperation = (typeof allDatabaseOperations)[number];

--- a/workflow-bridge-lambda/src/index.ts
+++ b/workflow-bridge-lambda/src/index.ts
@@ -25,37 +25,38 @@ exports.handler = async (event: {
   ];
 };
 
-const getPinboardById = (apiBase: "content" | "stubs") => async (
-  id: string
-) => {
-  const contentResponse = await fetch(
-    `${WORKFLOW_DATASTORE_API_URL}/${apiBase}/${id}`
-  );
-  if (contentResponse.status === 404) {
-    return {
-      id,
-      isNotFound: true,
-    };
-  }
-  if (!contentResponse.ok) {
-    throw Error(`${contentResponse.status} ${await contentResponse.text()}`);
-  }
-  const data = ((await contentResponse.json()) as {
-    data: {
-      externalData: {
-        status: string;
+const getPinboardById =
+  (apiBase: "content" | "stubs") => async (id: string) => {
+    const contentResponse = await fetch(
+      `${WORKFLOW_DATASTORE_API_URL}/${apiBase}/${id}`
+    );
+    if (contentResponse.status === 404) {
+      return {
+        id,
+        isNotFound: true,
       };
-      // there are other fields, but they're just being forwarded on
-    };
-  }).data;
-  if (!data) {
-    return {
-      id,
-      isNotFound: true,
-    };
-  }
-  return { ...data.externalData, ...data };
-};
+    }
+    if (!contentResponse.ok) {
+      throw Error(`${contentResponse.status} ${await contentResponse.text()}`);
+    }
+    const data = (
+      (await contentResponse.json()) as {
+        data: {
+          externalData: {
+            status: string;
+          };
+          // there are other fields, but they're just being forwarded on
+        };
+      }
+    ).data;
+    if (!data) {
+      return {
+        id,
+        isNotFound: true,
+      };
+    }
+    return { ...data.externalData, ...data };
+  };
 
 const getAllPinboardIds = async ({ isTrashed }: { isTrashed: boolean }) => {
   const stubsResponse = await fetch(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9672,10 +9672,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.8.6:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.6.tgz#5c174b29befd507f14b83e3c19f83fdc0e974b71"
+  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
because...
A) it's best practice 
B) following #247 , we want to use nice new features of TypeScript such as `satisfies` keyword (see https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#satisfies) which `prettier` didn't like

... this upgrade changes prettier's behaviour slightly so **re-formats a number of files as part of this diff**