### PR TITLE
[`searchMentionableUsers`] return empty array for empty groups rather than null

### DIFF
--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -19,12 +19,12 @@ export const searchMentionableUsers = async (
         LIMIT 5
     `,
   groups: await sql`
-    SELECT "shorthand", "name", (
+    SELECT "shorthand", "name", COALESCE((
         SELECT json_agg("email")
         FROM "User", "GroupMember"
         WHERE "shorthand" = "GroupMember"."groupShorthand"
         AND "GroupMember"."userGoogleID" = "User"."googleID"
-        ) AS "memberEmails"
+        ), '[]') AS "memberEmails"
     FROM "Group"
     WHERE "shorthand" ILIKE ${args.prefix + "%"}
     OR "name" ILIKE ${"%" + args.prefix + "%"}


### PR DESCRIPTION
Small _fix_ to the `searchMentionableUsers` query to return empty array for empty groups rather than null, to correctly adhere to our schema.