### PR TITLE
Add telemetry to Tour

### DIFF
--- a/client/src/feedback.tsx
+++ b/client/src/feedback.tsx
@@ -14,6 +14,11 @@ export const Feedback = () => {
   const [isOpen, setIsOpen] = useState(false);
   const tourProgress = useTourProgress();
 
+  const handleTourStart = () => {
+    tourProgress.start();
+    sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.TOUR_START);
+  };
+
   return (
     <div
       css={css`
@@ -178,7 +183,7 @@ export const Feedback = () => {
                 text-decoration: underline;
                 cursor: pointer;
               `}
-              onClick={useTourProgress().start}
+              onClick={handleTourStart}
             >
               Guided Tour
             </span>

--- a/client/src/feedback.tsx
+++ b/client/src/feedback.tsx
@@ -16,7 +16,9 @@ export const Feedback = () => {
 
   const handleTourStart = () => {
     tourProgress.start();
-    sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.TOUR_START);
+    sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
+      tourEvent: "start_tour",
+    });
   };
 
   return (

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -120,17 +120,8 @@ export const SendMessageArea = ({
 
   const sendItem = () =>
     confirmClaimable(verifiedGroupMentionShorthands?.length > 0).then(
-      (claimable) =>
-        (tourProgress.isRunning
-          ? (sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
-              tourEvent: "messaging",
-            }),
-            tourProgress.sendItem(() => {
-              setMessage("");
-              clearPayloadToBeSent();
-              setUnverifiedMentions([]);
-            }))
-          : _sendItem)({
+      (claimable) => {
+        const messageItem = {
           variables: {
             input: {
               type: payloadToBeSent?.type || "message-only",
@@ -143,7 +134,20 @@ export const SendMessageArea = ({
               claimable,
             },
           },
-        })
+        };
+        if (tourProgress.isRunning) {
+          sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
+            tourEvent: "messaging",
+          });
+          tourProgress.sendItem(() => {
+            setMessage("");
+            clearPayloadToBeSent();
+            setUnverifiedMentions([]);
+          })(messageItem);
+        } else {
+          _sendItem(messageItem);
+        }
+      }
     );
 
   return (

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -10,7 +10,7 @@ import { PendingItem } from "./types/PendingItem";
 import { composer } from "../colours";
 import SendArrow from "../icons/send.svg";
 import { buttonBackground } from "./styling";
-import { TelemetryContext, PINBOARD_TELEMETRY_TYPE } from "./types/Telemetry";
+import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { SvgSpinner } from "@guardian/source-react-components";
 import { isGroup, isUser } from "../../shared/graphql/extraTypes";
 import { useConfirmModal } from "./modal";
@@ -122,11 +122,14 @@ export const SendMessageArea = ({
     confirmClaimable(verifiedGroupMentionShorthands?.length > 0).then(
       (claimable) =>
         (tourProgress.isRunning
-          ? tourProgress.sendItem(() => {
+          ? (sendTelemetryEvent?.(
+              PINBOARD_TELEMETRY_TYPE.TOUR_INTERACTIVE_MESSAGING
+            ),
+            tourProgress.sendItem(() => {
               setMessage("");
               clearPayloadToBeSent();
               setUnverifiedMentions([]);
-            })
+            }))
           : _sendItem)({
           variables: {
             input: {

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -122,9 +122,9 @@ export const SendMessageArea = ({
     confirmClaimable(verifiedGroupMentionShorthands?.length > 0).then(
       (claimable) =>
         (tourProgress.isRunning
-          ? (sendTelemetryEvent?.(
-              PINBOARD_TELEMETRY_TYPE.TOUR_INTERACTIVE_MESSAGING
-            ),
+          ? (sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
+              tourEvent: "messaging",
+            }),
             tourProgress.sendItem(() => {
               setMessage("");
               clearPayloadToBeSent();

--- a/client/src/types/Telemetry.ts
+++ b/client/src/types/Telemetry.ts
@@ -23,11 +23,7 @@ export enum PINBOARD_TELEMETRY_TYPE {
   CANCEL_DELETE_ITEM = "CANCEL_DELETE_ITEM",
   UPDATE_ITEM = "UPDATE_ITEM",
   CANCEL_UPDATE_ITEM = "CANCEL_UPDATE_ITEM",
-  TOUR_START = "START_TOUR",
-  TOUR_CLOSE = "CLOSE_TOUR",
-  TOUR_FINISH = "FINISH_TOUR",
-  TOUR_INTERACTIVE_MESSAGING = "INTERACTIVE_MESSAGING",
-  TOUR_JUMP_STEP = "JUMP_TOUR_STEP",
+  INTERACTIVE_TOUR = "INTERACTIVE_TOUR",
 }
 
 export interface IPinboardEventTags {
@@ -39,6 +35,13 @@ export interface IPinboardEventTags {
   tab?: Tab;
   composerId?: string;
   composerSection?: string;
+  tourEvent?:
+    | "start_tour"
+    | "dismiss_tour"
+    | "finish_tour"
+    | "messaging"
+    | "complete_tour"
+    | "jump_tour";
   tourStepId?: string;
 }
 

--- a/client/src/types/Telemetry.ts
+++ b/client/src/types/Telemetry.ts
@@ -23,6 +23,11 @@ export enum PINBOARD_TELEMETRY_TYPE {
   CANCEL_DELETE_ITEM = "CANCEL_DELETE_ITEM",
   UPDATE_ITEM = "UPDATE_ITEM",
   CANCEL_UPDATE_ITEM = "CANCEL_UPDATE_ITEM",
+  TOUR_START = "START_TOUR",
+  TOUR_CLOSE = "CLOSE_TOUR",
+  TOUR_FINISH = "FINISH_TOUR",
+  TOUR_INTERACTIVE_MESSAGING = "INTERACTIVE_MESSAGING",
+  TOUR_JUMP_STEP = "JUMP_TOUR_STEP",
 }
 
 export interface IPinboardEventTags {
@@ -34,6 +39,7 @@ export interface IPinboardEventTags {
   tab?: Tab;
   composerId?: string;
   composerSection?: string;
+  tourStepId?: string;
 }
 
 type PinboardNotificationSetting = "ON" | "OFF";


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Set up a basic client-side telemetry when users:
- start the tour
- select a step from the initial Contents step (to track most 'popular' step)
- try sending interactive messaging in the Messaging step
- close the tour (before finishing)
- finish the tour in the last step

The events are captured as one telemetry type (i.e.`PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR`) but as separate tags

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested on CODE ✅

Example Grafana panel 
<img width="897" alt="image" src="https://user-images.githubusercontent.com/47318984/232526588-a9e9c694-9322-4951-bb23-7f1d4aa05e0a.png">
https://metrics.gutools.co.uk/d/b-tyvbs7z/pinboard?orgId=1&from=now-30m&to=now&refresh=1m&var-Stage=CODE&var-Interval=$__auto_interval_Interval&viewPanel=37

Interacting with the tour should send telemetry data in the Network tab 'event' e.g.
<img width="897" alt="image" src="https://user-images.githubusercontent.com/47318984/232527024-32213ab5-ab55-42c5-bc3d-ebf4648719a1.png">

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Grafana dashboard should log user interactions with the tour
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Tested on CODE
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->