### PR TITLE
[notifications-lambda] bump `web-push` to latest

### DIFF
--- a/notifications-lambda/package.json
+++ b/notifications-lambda/package.json
@@ -14,6 +14,6 @@
     "ts-node-dev": "^1.1.8"
   },
   "dependencies": {
-    "web-push": "^3.4.5"
+    "web-push": "^3.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13331,10 +13331,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-push@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/web-push/-/web-push-3.4.5.tgz#f94074ff150538872c7183e4d8881c8305920cf1"
-  integrity sha512-2njbTqZ6Q7ZqqK14YpK1GGmaZs3NmuGYF5b7abCXulUIWFSlSYcZ3NBJQRFcMiQDceD7vQknb8FUuvI1F7Qe/g==
+web-push@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/web-push/-/web-push-3.5.0.tgz#4576533746052eda3bd50414b54a1b0a21eeaeae"
+  integrity sha512-JC0V9hzKTqlDYJ+LTZUXtW7B175qwwaqzbbMSWDxHWxZvd3xY0C2rcotMGDavub2nAAFw+sXTsqR65/KY2A5AQ==
   dependencies:
     asn1.js "^5.3.0"
     http_ece "1.1.0"


### PR DESCRIPTION
...hopefully removing the runtime log error line about deprecated use of `Buffer()`
