### PR TITLE
detect grid links on paste and convert to proper payload

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -1554,6 +1554,7 @@ type Query {
   getPinboardByComposerId(composerId: String!): WorkflowStub
   # grid-bridge-lambda queries
   getGridSearchSummary(apiUrl: String!): GridSearchSummary
+  asGridPayload(gridUrl: String!): AWSJSON
 }
 
 type Mutation {
@@ -1757,7 +1758,7 @@ type PinboardIdWithItemCounts {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1778,7 +1779,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "claimItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1799,7 +1800,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1820,7 +1821,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "deleteItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1841,7 +1842,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "editItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1862,7 +1863,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1883,7 +1884,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1904,7 +1905,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -1925,7 +1926,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getGroupPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1946,7 +1947,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getItemCounts",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1967,7 +1968,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1988,7 +1989,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2009,7 +2010,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2030,7 +2031,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2051,7 +2052,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2161,6 +2162,27 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::AppSync::DataSource",
     },
+    "pinboardappsyncapigridbridgelambdadsQueryasGridPayloadResolver57F5D7B0": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapigridbridgelambdads1C89A823",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "grid_bridge_lambda_ds",
+        "FieldName": "asGridPayload",
+        "Kind": "UNIT",
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
+$util.toJson($ctx.result)",
+        "TypeName": "Query",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
     "pinboardappsyncapigridbridgelambdadsQuerygetGridSearchSummaryResolverA1738BE2": Object {
       "DependsOn": Array [
         "pinboardappsyncapigridbridgelambdads1C89A823",
@@ -2176,7 +2198,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2301,7 +2323,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2322,7 +2344,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2343,7 +2365,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : fd845e304dc55720f7e58680d37ce463
+        "ResponseMappingTemplate": "## schema checksum : fcbbae1038ac748790e892b3e5fb8767
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -259,3 +259,9 @@ export const gqlGetGridSearchSummary = gql`
         }
     }
 `;
+
+export const gqlAsGridPayload = (gridUrl: string) => gql`
+    query AsGridPayload {
+        asGridPayload(gridUrl: "${gridUrl}")
+    }
+`;

--- a/client/src/editItem.tsx
+++ b/client/src/editItem.tsx
@@ -17,7 +17,8 @@ interface EditItemProps {
 }
 
 export const EditItem = ({ item, cancel }: EditItemProps) => {
-  const { payloadToBeSent, clearPayloadToBeSent } = useGlobalStateContext();
+  const { payloadToBeSent, setPayloadToBeSent, clearPayloadToBeSent } =
+    useGlobalStateContext();
   const sendTelemetryEvent = useContext(TelemetryContext);
 
   const telemetryPayloadCommon = {
@@ -78,6 +79,7 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
     >
       <ItemInputBox
         payloadToBeSent={payloadToBeSent}
+        setPayloadToBeSent={setPayloadToBeSent}
         clearPayloadToBeSent={clearPayloadToBeSent}
         message={message || ""}
         setMessage={setMessage}

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -359,6 +359,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
           <SendMessageArea
             onSuccessfulSend={onSuccessfulSend}
             payloadToBeSent={maybeEditingItemId ? null : payloadToBeSent}
+            setPayloadToBeSent={setPayloadToBeSent}
             clearPayloadToBeSent={clearPayloadToBeSent}
             onError={(error) => setError(pinboardId, error)}
             userEmail={userEmail}

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -19,6 +19,7 @@ import { useTourProgress } from "./tour/tourState";
 
 interface SendMessageAreaProps {
   payloadToBeSent: PayloadAndType | null;
+  setPayloadToBeSent: (payload: PayloadAndType | null) => void;
   clearPayloadToBeSent: () => void;
   onSuccessfulSend: (item: PendingItem, mentionEmails: string[]) => void;
   onError: (error: ApolloError) => void;
@@ -29,6 +30,7 @@ interface SendMessageAreaProps {
 
 export const SendMessageArea = ({
   payloadToBeSent,
+  setPayloadToBeSent,
   clearPayloadToBeSent,
   onSuccessfulSend,
   onError,
@@ -62,11 +64,6 @@ export const SendMessageArea = ({
 
   const sendTelemetryEvent = useContext(TelemetryContext);
 
-  const hasGridUrl = (message: string) => {
-    const gridUrlRegex = /https:\/\/media.gutools.co.uk/;
-    return !!message.match(gridUrlRegex);
-  };
-
   const [_sendItem, { loading: isItemSending }] = useMutation<{
     createItem: Item;
   }>(gqlCreateItem, {
@@ -78,9 +75,6 @@ export const SendMessageArea = ({
         },
         verifiedIndividualMentionEmails
       );
-      if (hasGridUrl(message)) {
-        sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.GRID_LINK_PASTED);
-      }
       sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.MESSAGE_SENT, {
         pinboardId: sendMessageResult.createItem.pinboardId,
         messageType: payloadToBeSent?.type || "message-only",
@@ -164,6 +158,7 @@ export const SendMessageArea = ({
       {claimableConfirmModalElement}
       <ItemInputBox
         payloadToBeSent={payloadToBeSent}
+        setPayloadToBeSent={setPayloadToBeSent}
         clearPayloadToBeSent={clearPayloadToBeSent}
         message={message}
         setMessage={setMessage}

--- a/grid-bridge-lambda/run.ts
+++ b/grid-bridge-lambda/run.ts
@@ -1,11 +1,45 @@
 import { handler } from "./src";
+import prompts from "prompts";
 
-handler({
-  arguments: {
-    apiUrl:
-      "https://api.media.test.dev-gutools.co.uk/images?q=flag%20%20~%22australia%22%20%23xyz%20country:%22United%20Kingdom%22&length=1&orderBy=-uploadTime",
-  },
-})
-  .then(JSON.stringify)
-  .then(console.log)
-  .catch(console.error);
+(async () => {
+  const { args } = await prompts({
+    type: "select",
+    name: "args",
+    message: "",
+    choices: [
+      {
+        title: "getGridSearchSummary",
+        value: {
+          apiUrl:
+            "https://api.media.test.dev-gutools.co.uk/images?q=flag%20%20~%22australia%22%20%23xyz%20country:%22United%20Kingdom%22&length=1&orderBy=-uploadTime",
+        },
+        selected: true,
+      },
+      {
+        title: "asGridPayload (grid-search)",
+        value: {
+          gridUrl:
+            "https://media.test.dev-gutools.co.uk/search?query=test&nonFree=true",
+        },
+      },
+      {
+        title: "asGridPayload (grid-original)",
+        value: {
+          gridUrl:
+            "https://media.test.dev-gutools.co.uk/images/65c8e0cb691ccedb73f30822d2e9c9999d3a0e87",
+        },
+      },
+      {
+        title: "asGridPayload (grid-crop)",
+        value: {
+          gridUrl:
+            "https://media.test.dev-gutools.co.uk/images/65c8e0cb691ccedb73f30822d2e9c9999d3a0e87?crop=0_0_20772_12500",
+        },
+      },
+    ],
+  });
+  handler({ arguments: args })
+    .then(JSON.stringify)
+    .then(console.dir)
+    .catch(console.error);
+})();

--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -16,7 +16,7 @@ export const QUERIES = {
     "getPinboardsByIds",
     "getPinboardByComposerId",
   ] as const,
-  grid: ["getGridSearchSummary"] as const,
+  grid: ["getGridSearchSummary", "asGridPayload"] as const,
 } as const;
 
 type QueriesFromCodeGen = keyof Required<Omit<Query, "__typename">>;

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -19,6 +19,7 @@ type Query {
   getPinboardByComposerId(composerId: String!): WorkflowStub
   # grid-bridge-lambda queries
   getGridSearchSummary(apiUrl: String!): GridSearchSummary
+  asGridPayload(gridUrl: String!): AWSJSON
 }
 
 type Mutation {


### PR DESCRIPTION
https://trello.com/c/jvhO7GKf/619-pinboard-turn-grid-links-into-proper-payloads

We observed in PROD that users are still pasting grid links (probably muscle memory from doing so with email, chat etc.)...
![image](https://user-images.githubusercontent.com/19289579/232813492-ca8d96c8-bac5-4a97-ae6f-0f2d10e325c3.png)

So now we detect on paste (rather than on send) - if the pasted text is a grid link we call a NEW `asGridPayload` GraphQL Query, handled by `grid-bridge-lambda` which based on the URL builds the payload (calling out to grid API if needs be) and type (`grid-search`, `grid-original` or `grid-crop`) and calls the `setPayloadToBeSent` (just like `Add to 📌` and drag'n'drop does) before finally removing the pasted grid link from the message). Note we've retained the telemetry event.

![paste_grid_links](https://user-images.githubusercontent.com/19289579/232816993-4d09a3c1-e2ae-4c0f-9b34-1d64a20c7f4e.gif)
