### PR TITLE
hide/disable interactive tour/demo in workflow (a.k.a. 'inline mode')

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -42,6 +42,7 @@ import {
 import { UserLookup } from "./types/UserLookup";
 import {
   InlineMode,
+  isInlineMode,
   WORKFLOW_PINBOARD_ELEMENTS_QUERY_SELECTOR,
 } from "./inline/inlineMode";
 import { getAgateFontFaceIfApplicable } from "../fontNormaliser";
@@ -63,11 +64,6 @@ export const PinBoardApp = ({
   hasApolloAuthErrorVar,
   userEmail,
 }: PinBoardAppProps) => {
-  const isInlineMode = useMemo(
-    () => window.location.hostname.startsWith("workflow."),
-    []
-  );
-
   const [payloadToBeSent, setPayloadToBeSent] = useState<PayloadAndType | null>(
     null
   );
@@ -428,7 +424,7 @@ export const PinBoardApp = ({
               }}
             >
               <TickContext.Provider value={lastTickTimestamp}>
-                {isInlineMode ? (
+                {useMemo(isInlineMode, []) ? (
                   <InlineMode
                     workflowPinboardElements={workflowPinboardElements}
                   />

--- a/client/src/feedback.tsx
+++ b/client/src/feedback.tsx
@@ -8,6 +8,7 @@ import UpChevron from "../icons/chevron-up.svg";
 import { agateSans } from "../fontNormaliser";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { useTourProgress } from "./tour/tourState";
+import { isInlineMode } from "./inline/inlineMode";
 
 export const Feedback = () => {
   const sendTelemetryEvent = useContext(TelemetryContext);
@@ -172,7 +173,7 @@ export const Feedback = () => {
             />
           </div>
         )}
-        {!tourProgress.isRunning && (
+        {!tourProgress.isRunning && !isInlineMode() && (
           <div
             css={css`
               color: white;

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -10,6 +10,9 @@ import { InlineModeWorkflowColumnHeading } from "./inlineModeWorkflowColumnHeadi
 export const WORKFLOW_PINBOARD_ELEMENTS_QUERY_SELECTOR =
   ".content-list-item__field--pinboard";
 
+export const isInlineMode = () =>
+  window.location.hostname.startsWith("workflow.");
+
 interface InlineModeProps {
   workflowPinboardElements: HTMLElement[];
 }

--- a/client/src/tour/tourState.tsx
+++ b/client/src/tour/tourState.tsx
@@ -32,6 +32,7 @@ import {
 import { userToMentionHandle } from "../mentionsUtil";
 import { LastItemSeenByUserLookup } from "../pinboard";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "../types/Telemetry";
+import { isInlineMode } from "../inline/inlineMode";
 
 type TourStepRef = React.MutableRefObject<HTMLDivElement | null>;
 
@@ -190,7 +191,8 @@ export const TourStateProvider: React.FC = ({ children }) => {
     if (
       isExpanded &&
       hasEverUsedTour ===
-        false /* explicit false check to ensure 'hasEverUsedTour' has actually been loaded */
+        false /* explicit false check to ensure 'hasEverUsedTour' has actually been loaded */ &&
+      !isInlineMode()
     ) {
       start();
     }


### PR DESCRIPTION
Since the interactive tour/demo 'auto-starts' for users who've never used pinboard, and the tour starts on the index view of `Panel` there's nowhere for it to display in workflow (`InlineModePanel`) and it doesn't make sense in its current form given the first few steps of the tour relate to the index view (which pinboard in workflow doesn't have, just chat - given users click on the cells in the pinboard column in workflow to select the pinboard they want).