### PR TITLE
add a spinner during pasted grid link resolution and block sending

### DIFF
--- a/client/gql.ts
+++ b/client/gql.ts
@@ -261,10 +261,10 @@ export const gqlGetGridSearchSummary = gql`
     }
 `;
 
-export const gqlAsGridPayload = (gridUrl: string) => gql`
-    query AsGridPayload {
-        asGridPayload(gridUrl: "${gridUrl}")
-    }
+export const gqlAsGridPayload = gql`
+  query AsGridPayload($gridUrl: String!) {
+    asGridPayload(gridUrl: $gridUrl)
+  }
 `;
 
 export const gqlVisitTourStep = gql`

--- a/client/src/editItem.tsx
+++ b/client/src/editItem.tsx
@@ -3,8 +3,8 @@ import { Item } from "../../shared/graphql/graphql";
 import { ItemInputBox } from "./itemInputBox";
 import { useGlobalStateContext } from "./globalState";
 import { css } from "@emotion/react";
-import { useMutation } from "@apollo/client";
-import { gqlEditItem } from "../gql";
+import { useLazyQuery, useMutation } from "@apollo/client";
+import { gqlAsGridPayload, gqlEditItem } from "../gql";
 import { palette, space } from "@guardian/source-foundations";
 import { agateSans } from "../fontNormaliser";
 import { composer } from "../colours";
@@ -69,6 +69,10 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
 
   const ref = useRef<HTMLDivElement | null>(null);
 
+  const [asGridPayload, { loading: isAsGridPayloadLoading }] = useLazyQuery<{
+    asGridPayload: string | null;
+  }>(gqlAsGridPayload);
+
   return (
     <div
       ref={ref}
@@ -85,6 +89,8 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
         setMessage={setMessage}
         isSending={loading}
         panelElement={ref.current}
+        asGridPayload={asGridPayload}
+        isAsGridPayloadLoading={isAsGridPayloadLoading}
       />
       <div
         css={css`
@@ -117,7 +123,7 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
               background-color: ${composer.primary[400]};
             }
           `}
-          disabled={loading || !canUpdate}
+          disabled={loading || !canUpdate || isAsGridPayloadLoading}
         >
           Update
         </button>

--- a/client/src/itemInputBox.tsx
+++ b/client/src/itemInputBox.tsx
@@ -4,15 +4,15 @@ import ReactTextareaAutocomplete from "@webscopeio/react-textarea-autocomplete";
 import { PayloadAndType } from "./types/PayloadAndType";
 import { palette, space } from "@guardian/source-foundations";
 import { PayloadDisplay } from "./payloadDisplay";
-import { Group, User } from "../../shared/graphql/graphql";
+import { Group, User } from "shared/graphql/graphql";
 import { AvatarRoundel } from "./avatarRoundel";
 import { agateSans } from "../fontNormaliser";
 import { scrollbarsCss } from "./styling";
 import { composer } from "../colours";
-import { useApolloClient } from "@apollo/client";
-import { gqlAsGridPayload, gqlSearchMentionableUsers } from "../gql";
+import { LazyQueryHookOptions, useApolloClient } from "@apollo/client";
+import { gqlSearchMentionableUsers } from "../gql";
 import { SvgSpinner } from "@guardian/source-react-components";
-import { isGroup, isUser } from "../../shared/graphql/extraTypes";
+import { isGroup, isUser } from "shared/graphql/extraTypes";
 import { groupToMentionHandle, userToMentionHandle } from "./mentionsUtil";
 import { useTourProgress } from "./tour/tourState";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
@@ -124,6 +124,10 @@ interface ItemInputBoxProps {
   addUnverifiedMention?: (userOrGroup: User | Group) => void;
   panelElement: HTMLElement | null;
   isSending: boolean;
+  asGridPayload: (
+    options?: Partial<LazyQueryHookOptions<{ asGridPayload: string | null }>>
+  ) => unknown;
+  isAsGridPayloadLoading: boolean;
 }
 
 export const ItemInputBox = ({
@@ -136,6 +140,8 @@ export const ItemInputBox = ({
   addUnverifiedMention,
   panelElement,
   isSending,
+  asGridPayload,
+  isAsGridPayloadLoading,
 }: ItemInputBoxProps) => {
   const sendTelemetryEvent = useContext(TelemetryContext);
 
@@ -195,16 +201,17 @@ export const ItemInputBox = ({
     const pastedText = clipboardData.getData("text")?.trim();
     if (pastedText.startsWith(gridBaseUrl)) {
       sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.GRID_LINK_PASTED);
-      apolloClient
-        .query<{ asGridPayload: string | null }>({
-          query: gqlAsGridPayload(pastedText),
-        })
-        .then(({ data: { asGridPayload } }) => {
+      asGridPayload({
+        variables: {
+          gridUrl: pastedText,
+        },
+        onCompleted: ({ asGridPayload }) => {
           if (asGridPayload) {
             setPayloadToBeSent(JSON.parse(asGridPayload));
             setMessage(message.replace(pastedText, "")); // remove the link from the message
           }
-        }); //TODO add error handling
+        },
+      }); //TODO add error handling
     }
   };
 
@@ -253,7 +260,7 @@ export const ItemInputBox = ({
           ((event) => {
             event.stopPropagation();
             if (isEnterKey(event)) {
-              if (message || payloadToBeSent) {
+              if (!isAsGridPayloadLoading && (message || payloadToBeSent)) {
                 sendItem();
               }
               event.preventDefault();
@@ -281,6 +288,19 @@ export const ItemInputBox = ({
         `}
         boundariesElement={panelElement || undefined}
       />
+      {isAsGridPayloadLoading && (
+        <div
+          css={css`
+            display: flex;
+            align-items: center;
+            padding: 5px;
+            ${agateSans.small({ fontStyle: "italic" })};
+          `}
+        >
+          <SvgSpinner size="small" />
+          &nbsp;please wait a moment
+        </div>
+      )}
       {payloadToBeSent && (
         <div
           css={css`

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -1,9 +1,9 @@
-import { ApolloError, useMutation } from "@apollo/client";
+import { ApolloError, useLazyQuery, useMutation } from "@apollo/client";
 import { css } from "@emotion/react";
 import { palette, space } from "@guardian/source-foundations";
 import React, { useContext, useState } from "react";
 import { Group, Item, User } from "../../shared/graphql/graphql";
-import { gqlCreateItem } from "../gql";
+import { gqlAsGridPayload, gqlCreateItem } from "../gql";
 import { ItemInputBox } from "./itemInputBox";
 import { PayloadAndType } from "./types/PayloadAndType";
 import { PendingItem } from "./types/PendingItem";
@@ -144,6 +144,10 @@ export const SendMessageArea = ({
       }
     );
 
+  const [asGridPayload, { loading: isAsGridPayloadLoading }] = useLazyQuery<{
+    asGridPayload: string | null;
+  }>(gqlAsGridPayload);
+
   return (
     <div
       css={css`
@@ -166,6 +170,8 @@ export const SendMessageArea = ({
         addUnverifiedMention={addUnverifiedMention}
         panelElement={panelElement}
         isSending={isItemSending}
+        asGridPayload={asGridPayload}
+        isAsGridPayloadLoading={isAsGridPayloadLoading}
       />
       <button
         css={css`
@@ -189,7 +195,11 @@ export const SendMessageArea = ({
           }
         `}
         onClick={sendItem}
-        disabled={isItemSending || !(message || payloadToBeSent)}
+        disabled={
+          isItemSending ||
+          isAsGridPayloadLoading ||
+          !(message || payloadToBeSent)
+        }
       >
         {isItemSending ? (
           <SvgSpinner />


### PR DESCRIPTION
In #257 we began detecting grid links being pasted and convert them to real payloads. However this was done silently in the background, and as a result we observed in the wild some links still being sent as is, the theory being that the users hit send before the payload had been retrieved/built/added (CC @CDicksonG). This PR adds a spinner and also blocks sending whilst a grid link is being converted...
![show-grid-link-conversion-spinner](https://github.com/guardian/pinboard/assets/19289579/f1e80e9e-b477-4878-8764-c08f3b9d9020)
(note GIF was recorded whilst network was severely throttled so you can see spinner for longer - it's normally much faster obvs.)