### PR TITLE
grey out zero counts in workflow column and use spinner during loading

### DIFF
--- a/client/src/inline/inlineModePinboardToggle.tsx
+++ b/client/src/inline/inlineModePinboardToggle.tsx
@@ -3,10 +3,11 @@ import React, { useEffect, useMemo } from "react";
 import { css } from "@emotion/react";
 import root from "react-shadow/emotion";
 import { composer, pinboard, pinMetal } from "../../colours";
-import { PinboardIdWithItemCounts } from "../../../shared/graphql/graphql";
+import { PinboardIdWithItemCounts } from "shared/graphql/graphql";
 import { palette, space } from "@guardian/source-foundations";
 import { agateSans } from "../../fontNormaliser";
 import { useGlobalStateContext } from "../globalState";
+import { SvgSpinner } from "@guardian/source-react-components";
 
 export const COUNT_COLUMNS_MIN_WIDTH = 25;
 
@@ -89,8 +90,10 @@ const InlineModePinboardToggle = ({
           padding: 2px 12px 2px 3px;
           margin: 0 3px;
           background-color: ${isSelected ? pinboard["500"] : "none"};
+          color: ${palette.neutral[86]};
           &:hover {
             background-color: ${pinboard[isSelected ? "800" : "500"]};
+            color: ${palette.neutral[0]};
           }
         `}
       >
@@ -122,12 +125,32 @@ const InlineModePinboardToggle = ({
           css={css`
             display: inline-block;
             min-width: ${COUNT_COLUMNS_MIN_WIDTH}px;
-            font-weight: bold;
             text-align: right;
+            ${counts?.totalCount === 0
+              ? ""
+              : `font-weight: bold; color: ${palette.neutral[0]};`}
           `}
         >
           {counts?.totalCount}
         </span>
+        {counts?.totalCount === undefined && (
+          <div
+            css={css`
+              svg {
+                width: 15px;
+                height: 15px;
+                circle {
+                  stroke: ${palette.neutral[86]};
+                }
+                path {
+                  stroke: ${palette.neutral[60]};
+                }
+              }
+            `}
+          >
+            <SvgSpinner />
+          </div>
+        )}
       </div>
     </root.div>
   );


### PR DESCRIPTION
User noted that it's harder to spot the pinboards with any messages when the zeros are shown. We discussed hiding the zeros, but that would make no distinction between the 'loading state' and there being zero pinboard items, so...

- introduced a spinner when in the loading state to make it explicit
- greyed out the zero (rather than removing, because blank made it less obvious the cell was clickable) [note the grey is the same as that for other columns in workflow, notably the flags columns - same colour as when flag is not set]

| Before | After |
|--------|--------|
| ![workflow_column_before](https://github.com/guardian/pinboard/assets/19289579/b2a5765b-733b-463f-bc23-9b595abaf271) | ![workflow_column_after](https://github.com/guardian/pinboard/assets/19289579/6327703f-4b90-4b59-b5be-9ab4b47e3a36) |