### PR TITLE
reinstate emails for missed individual mentions

### DIFF
--- a/email-lambda/README.md
+++ b/email-lambda/README.md
@@ -5,8 +5,8 @@ As a fallback for users without desktop notifications turned-on etc. we'd like u
 This lambda runs every 5 minutes and does the following...
 
 1. queries the DB for
-   - items with individual mentions which have remained unread for more than an hour [by the mentioned user(s)] which hasn't had it's `isEmailEvaluated` set to true.
-   - items where `Central Production` is group mentioned and hasn't already had it's `isEmailEvaluated` set to true.
+   - items with individual mentions which have remained unread for more than an hour (by those mentioned) and haven't had `isEmailEvaluated` set to true.
+   - items where `Central Production` is group mentioned and haven't had `isEmailEvaluated` set to true.
 1. collates all items into per-user data structure, and then per-pinboard within that
 1. looks-up the working titles and headlines from workflow (by invoking [`workflow-bridge-lambda`](../workflow-bridge-lambda))
 1. loops through the users, sending them an email (using [AWS Simple Email Service (SES)](https://aws.amazon.com/ses/)) from the relevant pinboard domain - `mentions@pinboard.code.dev-gutools.co.uk` or `mentions@pinboard.gutools.co.uk`

--- a/email-lambda/README.md
+++ b/email-lambda/README.md
@@ -4,9 +4,9 @@ As a fallback for users without desktop notifications turned-on etc. we'd like u
 
 This lambda runs every 5 minutes and does the following...
 
-1. ~~queries the DB for items with mentions etc. which have remained unread for more than an hour [by the mentioned user(s)] which hasn't had it's `isEmailEvaluated` set to true.~~
-
-1. queries the DB for items where `Central Production` is group mentioned and hasn't already had it's `isEmailEvaluated` set to true.
+1. queries the DB for
+   - items with individual mentions which have remained unread for more than an hour [by the mentioned user(s)] which hasn't had it's `isEmailEvaluated` set to true.
+   - items where `Central Production` is group mentioned and hasn't already had it's `isEmailEvaluated` set to true.
 1. collates all items into per-user data structure, and then per-pinboard within that
 1. looks-up the working titles and headlines from workflow (by invoking [`workflow-bridge-lambda`](../workflow-bridge-lambda))
 1. loops through the users, sending them an email (using [AWS Simple Email Service (SES)](https://aws.amazon.com/ses/)) from the relevant pinboard domain - `mentions@pinboard.code.dev-gutools.co.uk` or `mentions@pinboard.gutools.co.uk`

--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -104,8 +104,7 @@ export const handler = async () => {
                   ...(innerAcc[email]?.[pinboardId]?.items || []),
                   {
                     ...itemFragment,
-                    thumbnailURL:
-                      (payload && JSON.parse(payload)?.thumbnail) || null,
+                    thumbnailURL: payload?.thumbnail || null,
                     timestamp: new Date(timestamp), // TODO improve timezone locality before displaying in emails
                   },
                 ],


### PR DESCRIPTION
#259 introduced the `email-lambda` and supporting changes, but was temporarily limited to a special case of group mentions for `Central Production` (to complement them being made group mentionable) .

This PR mainly uncomments (with a little tweak) the query for fetching missed individual mentions [items which have remained unread by the mentioned person(s) for more than an hour].
