### PR TITLE
[email-lambda] make claims clearer (as they won't have a `message`)

### DIFF
--- a/email-lambda/run.ts
+++ b/email-lambda/run.ts
@@ -17,6 +17,7 @@ const sampleData: PerPersonDetails = {
         lastName: "Nutt",
         avatarUrl: "https://thumbs.dreamstime.com/z/hazelnut-5422216.jpg",
         id: "2616",
+        type: "message-only",
         message: "Hi @Tom Richards this is a test message for the email-lambda",
         thumbnailURL: null,
         timestamp: new Date("2023-05-12T11:48:25.504Z"),
@@ -26,11 +27,22 @@ const sampleData: PerPersonDetails = {
         lastName: "Twishes",
         avatarUrl: null, // intentionally null
         id: "2617",
+        type: "grid-crop",
         message:
           "Here's another mention @Tom Richards but this time with a piccy...",
         thumbnailURL:
           "https://d2av06b16cc3yv.cloudfront.net/a/7/3/9/f/2/a739f22a4fe2da157cc7602c118406639653013a?Expires=1683895136&Signature=SNNeWOEggAL6Ym15Hcm3M1o8PNZG-JRdFmlSZcyPrFbnSbMsnaCkrqAmt2zaihhAwDztwytARUTW3gE60QXkHw6WnSMlof1UaijSpbfy9bKBeypD614AI5DihRmaWLkR1HxYa8czVW5kEvZ1iTeL1PIyjXs~SjIUvdan11w1yIqVptQaWW8L87SrzI8SrPSFRHxAYG3wvvSD93eRhLLbifnGD0Lyzme7e9nZ3pSppzA~a1E5p-zzj-3YphwjXNGeFrXITDbg1sqycFOcQmIWM535rd7bg2lMywFfFjl717pRW17x3jD9A7wxpioJCzgSQ1tMMH1xdfBEuI1~-OFjPw__&Key-Pair-Id=APKAJPTTPZNNPHQSSUAQ",
         timestamp: new Date("2023-05-12T12:07:10.039Z"),
+      },
+      {
+        firstName: "Hazel",
+        lastName: "Nutt",
+        avatarUrl: "https://thumbs.dreamstime.com/z/hazelnut-5422216.jpg",
+        id: "2619",
+        type: "claim",
+        message: null,
+        thumbnailURL: null,
+        timestamp: new Date("2023-05-12T11:48:25.504Z"),
       },
     ],
   },
@@ -44,6 +56,7 @@ const sampleData: PerPersonDetails = {
         avatarUrl:
           "https://assets.epicurious.com/photos/57714624e43289453ac28e41/1:1/w_2560%2Cc_limit/diner-bacon-hero-22062016.jpg",
         id: "2618",
+        type: "message-only",
         message: "Hi @Tom Richards this is really great",
         thumbnailURL: null,
         timestamp: new Date("2023-05-12T12:12:43.803Z"),

--- a/email-lambda/src/email.tsx
+++ b/email-lambda/src/email.tsx
@@ -8,6 +8,7 @@ import { pinboard, pinMetal } from "client/colours";
 
 interface ItemFragment {
   id: string;
+  type: string;
   timestamp: Date;
   message: string | null;
   thumbnailURL: string | null;
@@ -67,7 +68,15 @@ export const EmailBody = (perPersonDetails: PerPersonDetails) => (
           <ul style={{ padding: "0 10px", listStyle: "none" }}>
             {items.map(
               (
-                { id, firstName, lastName, avatarUrl, message, thumbnailURL },
+                {
+                  id,
+                  firstName,
+                  lastName,
+                  avatarUrl,
+                  type,
+                  message,
+                  thumbnailURL,
+                },
                 index
               ) => (
                 <li
@@ -105,6 +114,7 @@ export const EmailBody = (perPersonDetails: PerPersonDetails) => (
                     style={{ marginLeft: `${AVATAR_SIZE + AVATAR_GAP + 2}px` }}
                   >
                     {message}
+                    {type === "claim" && <em>...claimed a request</em>}
                     <a
                       href={`https://workflow.${toolsDomain}/redirect/${pinboardId}?${EXPAND_PINBOARD_QUERY_PARAM}=true&${PINBOARD_ITEM_ID_QUERY_PARAM}=${id}`}
                     >

--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -19,7 +19,7 @@ export const handler = async () => {
   try {
     // find unread mentions (individual) older than X (which haven't already been emailed about)
     /*    const missedIndividualMentions = await sql`
-        SELECT "id", "message", "payload", "timestamp", "pinboardId", "firstName", "lastName", "avatarUrl", (
+        SELECT "id", "type", "message", "payload", "timestamp", "pinboardId", "firstName", "lastName", "avatarUrl", (
             SELECT json_agg("userEmail")
             FROM "LastItemSeenByUser"
             WHERE "LastItemSeenByUser"."pinboardId" = "Item"."pinboardId"
@@ -33,7 +33,7 @@ export const handler = async () => {
     `;*/
 
     const centralProductionMentions = await sql`
-        SELECT "id", "message", "payload", "timestamp", "pinboardId", "firstName", "lastName", "avatarUrl",
+        SELECT "id", "type", "message", "payload", "timestamp", "pinboardId", "firstName", "lastName", "avatarUrl",
                (
                    SELECT json_agg("primaryEmail")
                    FROM "Group"
@@ -88,7 +88,7 @@ export const handler = async () => {
     const finalStructure: FinalStructure = itemsToEmailAbout.reduce(
       (
         outerAcc: FinalStructure,
-        { id, message, payload, timestamp, pinboardId, unreadMentions }
+        { payload, timestamp, pinboardId, unreadMentions, ...itemFragment }
       ) =>
         unreadMentions?.reduce(
           (innerAcc: FinalStructure, email: string) => ({
@@ -102,9 +102,8 @@ export const handler = async () => {
                 items: [
                   ...(innerAcc[email]?.[pinboardId]?.items || []),
                   {
-                    id,
-                    message,
-                    thumbnail:
+                    ...itemFragment,
+                    thumbnailURL:
                       (payload && JSON.parse(payload)?.thumbnail) || null,
                     timestamp: new Date(timestamp), // TODO improve timezone locality before displaying in emails
                   },


### PR DESCRIPTION
#259 introduced the `email-lambda` and supporting changes, but was temporarily limited to a special case of group mentions for `Central Production` (to complement them being made group mentionable). A real production use case of this revealed that users also receive an email for when a request is claimed (because the the `groupMentions` are reused for the 'claim' item so that a notification goes out. However in this scenario the `message` will be blank so the email looked a bit rubbish. This PR adds in `...claimed a request` text where the item type is `claim`...
![image](https://github.com/guardian/pinboard/assets/19289579/0bb4705a-bced-48b5-b3c9-f39b828a7a04)

Also fixed a nasty bug where the sender's name & avatar were not coming through to the email template.