### PR TITLE
always capture `composerId` tag for `MESSAGE_SENT` telemetry events

### DIFF
--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -89,6 +89,7 @@ export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
         ReactDOM.createPortal(
           <InlineModePanel
             pinboardId={maybeSelectedPinboardId}
+            composerId={maybeSelectedNode.dataset.composerId || null}
             closePanel={() => setMaybeSelectedPinboardId(null)}
             workingTitle={maybeSelectedNode.dataset.workingTitle || null}
             headline={maybeSelectedNode.dataset.headline || null}

--- a/client/src/inline/inlineModePanel.tsx
+++ b/client/src/inline/inlineModePanel.tsx
@@ -14,6 +14,7 @@ export const INLINE_PANEL_WIDTH = 260;
 
 interface InlineModePanelProps {
   pinboardId: string;
+  composerId: string | null;
   closePanel: () => void;
   workingTitle: string | null;
   headline: string | null;
@@ -21,6 +22,7 @@ interface InlineModePanelProps {
 
 export const InlineModePanel = ({
   pinboardId,
+  composerId,
   closePanel,
   workingTitle,
   headline,
@@ -85,6 +87,7 @@ export const InlineModePanel = ({
         </Navigation>
         <Pinboard
           pinboardId={pinboardId}
+          composerId={composerId}
           isSelected
           isExpanded
           panelElement={panelRef.current}

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -288,6 +288,12 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
           <Pinboard
             key={pinboardId}
             pinboardId={pinboardId}
+            composerId={useMemo(
+              () =>
+                activePinboards.find((_) => _.id === pinboardId)?.composerId ||
+                null,
+              [activePinboards, pinboardId]
+            )}
             isExpanded={pinboardId === selectedPinboardId && isExpanded}
             isSelected={pinboardId === selectedPinboardId}
             panelElement={panelRef.current}
@@ -298,6 +304,7 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
       {maybePeekingAtPinboard && (
         <Pinboard
           pinboardId={maybePeekingAtPinboard.id}
+          composerId={maybePeekingAtPinboard.composerId}
           isExpanded={isExpanded}
           isSelected={true}
           panelElement={panelRef.current}

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -1,10 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useSubscription } from "@apollo/client";
-import {
-  Claimed,
-  Item,
-  LastItemSeenByUser,
-} from "../../shared/graphql/graphql";
+import { Claimed, Item, LastItemSeenByUser } from "shared/graphql/graphql";
 import { ScrollableItems } from "./scrollableItems";
 import { PendingItem } from "./types/PendingItem";
 import {
@@ -34,6 +30,7 @@ export interface LastItemSeenByUserLookup {
 
 interface PinboardProps {
   pinboardId: string;
+  composerId: string | null;
   isExpanded: boolean;
   isSelected: boolean;
   panelElement: HTMLDivElement | null;
@@ -41,6 +38,7 @@ interface PinboardProps {
 
 export const Pinboard: React.FC<PinboardProps> = ({
   pinboardId,
+  composerId,
   isExpanded,
   isSelected,
   panelElement,
@@ -364,6 +362,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
             onError={(error) => setError(pinboardId, error)}
             userEmail={userEmail}
             pinboardId={pinboardId}
+            composerId={composerId}
             panelElement={panelElement}
           />
         </div>

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -2,7 +2,7 @@ import { ApolloError, useLazyQuery, useMutation } from "@apollo/client";
 import { css } from "@emotion/react";
 import { palette, space } from "@guardian/source-foundations";
 import React, { useContext, useState } from "react";
-import { Group, Item, User } from "../../shared/graphql/graphql";
+import { Group, Item, User } from "shared/graphql/graphql";
 import { gqlAsGridPayload, gqlCreateItem } from "../gql";
 import { ItemInputBox } from "./itemInputBox";
 import { PayloadAndType } from "./types/PayloadAndType";
@@ -12,7 +12,7 @@ import SendArrow from "../icons/send.svg";
 import { buttonBackground } from "./styling";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { SvgSpinner } from "@guardian/source-react-components";
-import { isGroup, isUser } from "../../shared/graphql/extraTypes";
+import { isGroup, isUser } from "shared/graphql/extraTypes";
 import { useConfirmModal } from "./modal";
 import { groupToMentionHandle, userToMentionHandle } from "./mentionsUtil";
 import { useTourProgress } from "./tour/tourState";
@@ -25,6 +25,7 @@ interface SendMessageAreaProps {
   onError: (error: ApolloError) => void;
   userEmail: string;
   pinboardId: string;
+  composerId: string | null;
   panelElement: HTMLDivElement | null;
 }
 
@@ -35,6 +36,7 @@ export const SendMessageArea = ({
   onSuccessfulSend,
   onError,
   pinboardId,
+  composerId,
   panelElement,
 }: SendMessageAreaProps) => {
   const [message, setMessage] = useState<string>("");
@@ -84,6 +86,7 @@ export const SendMessageArea = ({
         hasIndividualMentions: !!verifiedIndividualMentionEmails.length,
         hasGroupMentions: !!verifiedGroupMentionShorthands.length,
         isClaimable: sendMessageResult.createItem.claimable,
+        ...(composerId ? { composerId } : {}),
       });
       setMessage("");
       clearPayloadToBeSent();


### PR DESCRIPTION
Currently `composerId` is captured on all telemetry events where a `<pinboard-preselect ... />` element is present in the host application (i.e. when viewing a specific piece in composer).
For sends at least it would be better if we could attribute all send events (`MESSAGE_SENT`) with the `composerId` even if using Pinboard in grid, workflow etc. Since we have this information available already (with working title and headline retrieved from workflow via `workflow-bridge-lambda` periodically) in this PR we add `composerId` to the `tags` of the telemetry event in `SendMessageArea` component.

This will help us track progress towards our OKR; the ratio of pieces published to pieces where pinboard was used.

### Testing checklist
Send from...
- [x] specific composer piece (should work as before)
- [x] composer dashboard
- [x] grid
- [x] workflow (only after https://github.com/guardian/workflow-frontend/pull/403) 
- [x] 'peeking' at a team pinboard (so it's not part of your 'My Pinboards' at the point of send)

