### PR TITLE
'eat' query params from host application when read to ensure they don't hang around

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -49,6 +49,7 @@ import { getAgateFontFaceIfApplicable } from "../fontNormaliser";
 import { Global } from "@emotion/react";
 import { TourStateProvider } from "./tour/tourState";
 import { demoMentionableUsers, demoUser } from "./tour/tourConstants";
+import { readAndThenSilentlyDropQueryParamFromURL } from "./util";
 
 const PRESELECT_PINBOARD_HTML_TAG = "pinboard-preselect";
 const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
@@ -72,11 +73,10 @@ export const PinBoardApp = ({
     HTMLElement[]
   >([]);
 
-  const queryParams = new URLSearchParams(window.location.search);
   // using state here but without setter, because host application/SPA might change url
   // and lose the query param, but we don't want to lose the preselection
   const [openPinboardIdBasedOnQueryParam] = useState(
-    queryParams.get(OPEN_PINBOARD_QUERY_PARAM)
+    readAndThenSilentlyDropQueryParamFromURL(OPEN_PINBOARD_QUERY_PARAM)
   );
 
   const [preSelectedComposerId, setPreselectedComposerId] = useState<
@@ -87,7 +87,9 @@ export const PinBoardApp = ({
 
   const [isExpanded, setIsExpanded] = useState<boolean>(
     !!openPinboardIdBasedOnQueryParam || // expand by default when preselected via url query param
-      queryParams.get(EXPAND_PINBOARD_QUERY_PARAM)?.toLowerCase() === "true"
+      readAndThenSilentlyDropQueryParamFromURL(
+        EXPAND_PINBOARD_QUERY_PARAM
+      )?.toLowerCase() === "true"
   );
   const expandFloaty = () => setIsExpanded(true);
 

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -22,7 +22,7 @@ import { ItemsMap, LastItemSeenByUserLookup } from "./pinboard";
 import { scrollbarsCss } from "./styling";
 import { SvgArrowDownStraight } from "@guardian/source-react-components";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
-import { useThrottle } from "./util";
+import { readAndThenSilentlyDropQueryParamFromURL, useThrottle } from "./util";
 import { PendingItem } from "./types/PendingItem";
 import { UserLookup } from "./types/UserLookup";
 import { PINBOARD_ITEM_ID_QUERY_PARAM } from "../../shared/constants";
@@ -238,8 +238,10 @@ export const ScrollableItems = ({
           scrollToItem(itemIdToScrollTo);
         }, 1000);
         setHasProcessedItemIdInURL(true);
+        readAndThenSilentlyDropQueryParamFromURL(PINBOARD_ITEM_ID_QUERY_PARAM);
       } else if (Object.keys(refMap.current).length > 0) {
         setHasProcessedItemIdInURL(true);
+        readAndThenSilentlyDropQueryParamFromURL(PINBOARD_ITEM_ID_QUERY_PARAM);
       }
     }
   });

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -77,3 +77,15 @@ export const throttled = <E>(
 };
 
 export const useThrottle = throttled;
+
+export const readAndThenSilentlyDropQueryParamFromURL = (param: string) => {
+  const url = new URL(window.location.href);
+  const value = url.searchParams.get(param);
+  url.searchParams.delete(param);
+  window.history.replaceState(
+    window.history.state,
+    document.title,
+    url.toString()
+  );
+  return value;
+};

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -24,7 +24,6 @@ export const getWorkflowBridgeLambdaFunctionName = (stage: Stage) =>
 export const getEmailLambdaFunctionName = (stage: Stage) =>
   `pinboard-email-lambda-${stage}`;
 
-// FIXME we should probably 'eat' these query params once used (using `history.replaceState`)
 export const OPEN_PINBOARD_QUERY_PARAM = "pinboardId";
 export const PINBOARD_ITEM_ID_QUERY_PARAM = "pinboardItemId";
 export const EXPAND_PINBOARD_QUERY_PARAM = "expandPinboard";


### PR DESCRIPTION
Following on from #278 it made sense to address a long standing TODO to effectively 'use up' the query params which pinboard uses in the host application (currently `expandPinboard`, `pinboardId` and `pinboardItemId`).

This is a good idea, because often users will copy & paste URLs to give to other colleagues and we don't want potentially irrelevant pinboard query params being part of that and then opening pinboard to a random message on another users machine.