### PR TITLE
add 'Open in Grid' links to Pinboard group mention emails

### DIFF
--- a/email-lambda/src/email.tsx
+++ b/email-lambda/src/email.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   EXPAND_PINBOARD_QUERY_PARAM,
+  OPEN_PINBOARD_QUERY_PARAM,
   PINBOARD_ITEM_ID_QUERY_PARAM,
 } from "shared/constants";
 import { STAGE } from "shared/awsIntegration";
@@ -31,6 +32,8 @@ const toolsDomain =
 
 const AVATAR_SIZE = 25;
 const AVATAR_GAP = 3;
+
+const linkColour = "#007ABC"; // composer.primary.300
 
 export const getBasicMessage = (isGroupMentionEmail: boolean) =>
   isGroupMentionEmail ? "" : "You might have missed...";
@@ -125,25 +128,47 @@ export const buildEmailHTML = (
                     >
                       {message}
                       {type === "claim" && <em>...claimed the request</em>}
-                      <a
-                        href={`https://workflow.${toolsDomain}/redirect/${pinboardId}?${EXPAND_PINBOARD_QUERY_PARAM}=true&${PINBOARD_ITEM_ID_QUERY_PARAM}=${id}`}
+                      {thumbnailURL && (
+                        <img
+                          style={{
+                            display: "block",
+                            maxWidth: "200px",
+                            maxHeight: "100px",
+                            padding: "3px",
+                            border: "1px solid #DCDCDC",
+                            borderRadius: "4px",
+                            backgroundColor: "#FFFFFF",
+                          }}
+                          src={thumbnailURL}
+                        />
+                      )}
+                      <div
+                        style={{
+                          color: linkColour,
+                        }}
                       >
-                        {thumbnailURL && (
-                          <img
-                            style={{
-                              display: "block",
-                              maxWidth: "200px",
-                              maxHeight: "100px",
-                              padding: "3px",
-                              border: "1px solid #DCDCDC",
-                              borderRadius: "4px",
-                              backgroundColor: "#FFFFFF",
-                            }}
-                            src={thumbnailURL}
-                          />
-                        )}
-                        <div>Jump to this message</div>
-                      </a>
+                        Open message in{" "}
+                        <a
+                          style={{
+                            color: linkColour,
+                          }}
+                          href={`https://workflow.${toolsDomain}/redirect/${pinboardId}?${EXPAND_PINBOARD_QUERY_PARAM}=true&${PINBOARD_ITEM_ID_QUERY_PARAM}=${id}`}
+                        >
+                          Composer
+                        </a>{" "}
+                        or{" "}
+                        <a
+                          style={{
+                            color: linkColour,
+                          }}
+                          href={`https://media.${toolsDomain}/search?${OPEN_PINBOARD_QUERY_PARAM}=${pinboardId}&${PINBOARD_ITEM_ID_QUERY_PARAM}=${id}`.replace(
+                            ".code.",
+                            ".test."
+                          )}
+                        >
+                          Grid
+                        </a>
+                      </div>
                     </div>
                   </li>
                 )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
co-authored-by: @twrichards 
## What does this change?
An additional link in Pinboard group mention emails to open the message in Grid so that Grid users (e.g. news pics desk) can read it without having to navigate via Composer.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested in CODE. The email links open up the relevant pinboards in Composer and Grid.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<img width="699" alt="image" src="https://github.com/guardian/pinboard/assets/47318984/71a1e8db-2ffe-4405-8f24-7e5c7f792e61">
<img width="342" alt="image" src="https://github.com/guardian/pinboard/assets/47318984/8f3163a8-1f20-4171-a939-dd42b19a2b4b">
