### PR TITLE
only 'eat' query params if they're actually present to avoid unnecessarily re-writing host application's URL

### DIFF
--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -81,6 +81,7 @@ export const useThrottle = throttled;
 export const readAndThenSilentlyDropQueryParamFromURL = (param: string) => {
   const url = new URL(window.location.href);
   const value = url.searchParams.get(param);
+  if (!value) return value;
   url.searchParams.delete(param);
   window.history.replaceState(
     window.history.state,


### PR DESCRIPTION
Quick tweak to #279 as I noticed pinboard was rewriting query params unnecessarily under normal operation of say Grid.