### PR TITLE
some Firefox fixes

### DIFF
--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -34,7 +34,7 @@ export const AvatarRoundel = ({
         width: ${size}px;
         height: ${size}px;
         border-radius: 50%;
-        border: 1px solid ${neutral[93]};
+        box-shadow: 0 0 1px ${neutral[93]};
         background-color: ${composer.primary[300]};
         color: ${neutral[100]};
         display: flex;

--- a/client/src/claimableItem.tsx
+++ b/client/src/claimableItem.tsx
@@ -49,7 +49,7 @@ export const ClaimableItem = ({
         display: flex;
         align-items: center;
         gap: ${space[1]}px;
-        ${agateSans.xxsmall({ lineHeight: "tight" })};
+        ${agateSans.xxsmall()};
         margin-top: ${space[1]}px;
       `}
     >

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -109,15 +109,16 @@ export const ScrollableItems = ({
   );
   useEffect(() => {
     if (hasPinboardNeverBeenExpanded && scrollableArea && isExpanded) {
-      scrollableArea.scrollTop = Number.MAX_SAFE_INTEGER;
-      scrollableArea.scroll(0, Number.MAX_SAFE_INTEGER);
+      // Firefox on OSX 10.15 cannot handle having its scrollTop set to Number.MAX_SAFE_INTEGER, just reverts to zero
+      scrollableArea.scrollTop = scrollableArea.scrollHeight + 999999;
+      scrollableArea.scroll(0, scrollableArea.scrollHeight + 999999);
       setHasPinboardNeverBeenExpanded(false);
     }
   }, [scrollableArea, isExpanded]);
 
   const scrollToLastItem = () => {
     scrollableArea?.scroll({
-      top: Number.MAX_SAFE_INTEGER,
+      top: scrollableArea.scrollHeight + 999999,
       behavior: "smooth",
     });
     onScroll();

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -107,12 +107,10 @@ export const ScrollableItems = ({
     (node) => node && setScrollableArea(node),
     []
   );
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (hasPinboardNeverBeenExpanded && scrollableArea && isExpanded) {
       scrollableArea.scrollTop = Number.MAX_SAFE_INTEGER;
-      setTimeout(() => {
-        scrollableArea.scrollTop = Number.MAX_SAFE_INTEGER;
-      }, 100);
+      scrollableArea.scroll(0, Number.MAX_SAFE_INTEGER);
       setHasPinboardNeverBeenExpanded(false);
     }
   }, [scrollableArea, isExpanded]);


### PR DESCRIPTION
User reported scroll issues in Firefox which I was able to replicate, after some trial and error settled on a fix.
<img width="781" alt="image" src="https://github.com/guardian/pinboard/assets/19289579/5093315c-0b70-46a2-be42-26dc6283e472">


Also noticed and fixed some aliasing issues around the avatar roundel and some line-height issue.

Need to get better at testing on FF (not just Chrome where we're developing).