### PR TITLE
use `Video` to refer to MAM for 'Open in...' links in email

### DIFF
--- a/email-lambda/src/email.tsx
+++ b/email-lambda/src/email.tsx
@@ -163,7 +163,7 @@ export const buildEmailHTML = (
                           }}
                           href={`https://video.${toolsDomain}/videos?${OPEN_PINBOARD_QUERY_PARAM}=${pinboardId}&${PINBOARD_ITEM_ID_QUERY_PARAM}=${id}`}
                         >
-                          MAM
+                          Video
                         </a>
                         {" or "}
                         <a


### PR DESCRIPTION
Tiny follow-on to #283 