### PR TITLE
[email-lambda] ignore invalid pinboard IDs

### DIFF
--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -77,12 +77,24 @@ export const handler = async (maybeSendImmediatelyDetail?: {
       return;
     }
 
-    const pinboardIds = new Set<string>(
-      itemsToEmailAbout.map(({ pinboardId }) => pinboardId)
+    const pinboardIds = itemsToEmailAbout.reduce<string[]>(
+      (accumulator, item) => {
+        if (accumulator.includes(item.pinboardId)) {
+          return accumulator; // don't add duplicates
+        }
+        try {
+          parseInt(item.pinboardId);
+          return [...accumulator, item.pinboardId];
+        } catch (e) {
+          console.error("Invalid pinboard ID", item.pinboardId, item);
+          return accumulator;
+        }
+      },
+      []
     );
 
     const workflowLookupRequestPayload = {
-      arguments: { ids: [...pinboardIds] },
+      arguments: { ids: pinboardIds },
     };
 
     // lookup working titles & headlines for all the Pinboard IDs


### PR DESCRIPTION
Recently `email-lambda` started failing because a pesky item with `pinboardId` of `DEMO` sneaked into the DB (see https://github.com/guardian/pinboard/pull/289 for fix to that) and these were being blindly passed on to workflow which was then erroring (because not a number), causing email lambda to fail (without marking the item as processed - and therefore continued to fail until I cleaned up the entry in the DB).