### PR TITLE
throw error when real interaction happens against demo pinboard

### DIFF
--- a/client/src/editItem.tsx
+++ b/client/src/editItem.tsx
@@ -10,6 +10,7 @@ import { agateSans } from "../fontNormaliser";
 import { composer } from "../colours";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { useTourProgress } from "./tour/tourState";
+import { demoPinboardData } from "./tour/tourConstants";
 
 interface EditItemProps {
   item: Item;
@@ -53,8 +54,8 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
     },
   });
 
-  const editItem = () =>
-    (tourProgress.isRunning ? tourProgress.editItem(cancel) : _editItem)({
+  const editItem = () => {
+    const theUpdate = {
       variables: {
         itemId: item.id,
         input: {
@@ -63,7 +64,17 @@ export const EditItem = ({ item, cancel }: EditItemProps) => {
           type,
         },
       },
-    });
+    };
+    if (tourProgress.isRunning) {
+      return tourProgress.editItem(cancel)(theUpdate);
+    } else if (item.pinboardId === demoPinboardData.id) {
+      throw new Error(
+        "Demo/Tour NOT running, but message edit attempt on 'demo' pinboard"
+      );
+    } else {
+      return _editItem(theUpdate);
+    }
+  };
 
   const canUpdate = message || payloadToBeSent;
 

--- a/client/src/itemHoverMenu.tsx
+++ b/client/src/itemHoverMenu.tsx
@@ -12,6 +12,7 @@ import { gqlDeleteItem } from "../gql";
 import { Item } from "shared/graphql/graphql";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { useTourProgress } from "./tour/tourState";
+import { demoPinboardData } from "./tour/tourConstants";
 
 export const ITEM_HOVER_MENU_CLASS_NAME = "item-hover-menu";
 
@@ -80,6 +81,10 @@ export const ItemHoverMenu = ({
         // TODO show spinner whilst deleting
         if (tourProgress.isRunning) {
           setTimeout(() => tourProgress.deleteItem(item.id), 50);
+        } else if (item.pinboardId === demoPinboardData.id) {
+          throw new Error(
+            "Demo/Tour NOT running, but delete attempt on 'demo' pinboard"
+          );
         } else {
           deleteItem({ variables: { itemId: item.id } });
           sendTelemetryEvent?.(

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -16,6 +16,7 @@ import { isGroup, isUser } from "shared/graphql/extraTypes";
 import { useConfirmModal } from "./modal";
 import { groupToMentionHandle, userToMentionHandle } from "./mentionsUtil";
 import { useTourProgress } from "./tour/tourState";
+import { demoPinboardData } from "./tour/tourConstants";
 
 interface SendMessageAreaProps {
   payloadToBeSent: PayloadAndType | null;
@@ -151,6 +152,12 @@ export const SendMessageArea = ({
             clearReplyingToItemId();
             setUnverifiedMentions([]);
           })(messageItem);
+        } else if (
+          messageItem.variables.input.pinboardId === demoPinboardData.id
+        ) {
+          throw new Error(
+            "Demo/Tour NOT running, but message send attempt on 'demo' pinboard"
+          );
         } else {
           _sendItem(messageItem);
         }


### PR DESCRIPTION
Recently the `email-lambda` choked (and repeatedly failed every 5mins on the schedule) because it was trying to process an item where the `pinboardId` was `DEMO`, such items should never reach the database. I haven't yet been able to spot how that was possible in the logic, so I've added some safeguards for create, edit and delete of items which detects/throws when the tour isn't running but it still attempts a real mutation with a `pinboardId` of `DEMO` (so we'll have more info in Sentry) and it won't progress to perform the mutation.

According to the database it's happened 3 times in PROD to date (only the most recent had a mention and we noticed as a result of `email-lambda` errors).