### PR TITLE
zero tolerance alarming on complete failure for `email-lambda` and `archiver-lambda`

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -19,6 +19,7 @@ Object {
       "GuAutoScalingGroup",
       "GuAlarm",
       "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
       "GuCname",
       "GuCname",
       "GuCname",
@@ -206,6 +207,132 @@ Object {
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "ArchiverLambdaErrorPercentageAlarmForLambda974BA75F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "ArchiverLambda63644BDF",
+              },
+              " exceeded 0% error rate",
+            ],
+          ],
+        },
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High error % from ",
+              Object {
+                "Ref": "ArchiverLambda63644BDF",
+              },
+              " lambda in TEST",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Error % of ",
+                  Object {
+                    "Ref": "ArchiverLambda63644BDF",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "ArchiverLambda63644BDF",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "ArchiverLambda63644BDF",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "ArchiverLambdaServiceRoleDefaultPolicyF9A2D388": Object {
       "Properties": Object {

--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -23,6 +23,7 @@ Object {
       "GuCname",
       "GuCname",
       "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "49.5.0",
   },
@@ -1146,6 +1147,132 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "EmailLambdaErrorPercentageAlarmForLambda75B2E289": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "EmailLambda93E95E21",
+              },
+              " exceeded 0% error rate",
+            ],
+          ],
+        },
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High error % from ",
+              Object {
+                "Ref": "EmailLambda93E95E21",
+              },
+              " lambda in TEST",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Error % of ",
+                  Object {
+                    "Ref": "EmailLambda93E95E21",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "EmailLambda93E95E21",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "EmailLambda93E95E21",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "EmailLambdaServiceRoleCBE95916": Object {
       "Properties": Object {

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -60,6 +60,8 @@ import { GuCname } from "@guardian/cdk/lib/constructs/dns";
 // if changing should also change .nvmrc (at the root of repo)
 const LAMBDA_NODE_VERSION = lambda.Runtime.NODEJS_18_X;
 
+const ALARM_SNS_TOPIC_NAME = "Cloudwatch-Alerts";
+
 interface PinBoardStackProps extends GuStackProps {
   domainName: string;
 }
@@ -344,7 +346,7 @@ export class PinBoardStack extends GuStack {
     );
     new GuAlarm(this, "DatabaseJumpHostOverrunningAlarm", {
       app: APP,
-      snsTopicName: "Cloudwatch-Alerts",
+      snsTopicName: ALARM_SNS_TOPIC_NAME,
       alarmName: `${databaseJumpHostASG.autoScalingGroupName} instance running for more than 12 hours`,
       alarmDescription: `The ${APP} database 'jump host' should not run for more than 12 hours as it suggests the mechanism to shut it down when it's idle looks to be broken`,
       metric: new cloudwatch.Metric({
@@ -600,8 +602,9 @@ export class PinBoardStack extends GuStack {
         [ENVIRONMENT_VARIABLE_KEYS.databaseHostname]: databaseHostname,
       },
       monitoringConfiguration: {
-        noMonitoring: true,
-        // toleratedErrorPercentage: 0 TODO consider alarming on errors (need to provide sns topic which is sad since GuAlarm finds it for you)
+        toleratedErrorPercentage: 0,
+        snsTopicName: ALARM_SNS_TOPIC_NAME,
+        okAction: true,
       },
       fileName: "pinboard-email-lambda.zip",
       rules: [

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -565,8 +565,9 @@ export class PinBoardStack extends GuStack {
         [ENVIRONMENT_VARIABLE_KEYS.databaseHostname]: databaseHostname,
       },
       monitoringConfiguration: {
-        noMonitoring: true,
-        // toleratedErrorPercentage: 0 TODO consider alarming on errors (need to provide sns topic which is sad since GuAlarm finds it for you)
+        toleratedErrorPercentage: 0,
+        snsTopicName: ALARM_SNS_TOPIC_NAME,
+        okAction: true,
       },
       fileName: "pinboard-archiver-lambda.zip",
       rules: [


### PR DESCRIPTION
Currently `email-lambda` and `archiver-lambda` are the only ones using GuCDK patterns (other lambdas have yet to be migrated from vanilla CDK) so this PR focusses just on those. 

These lambdas should never fail completely (i.e. they should handle any failures within and log errors but not explode), recently `email-lambda` was completely failing (see #288) but only noticed from the metrics dashboard - alarm would've been much better... had been meaning to do this for a while (as you'll see in the TODOs which are now gone :tada).