### PR TITLE
fix broken Ⅹ button ('close pinboard') behaviour when the pinboard has been opened via query param

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -21,7 +21,7 @@ import {
   gqlOnManuallyOpenedPinboardIdsChanged,
   gqlSetWebPushSubscriptionForUser,
 } from "../gql";
-import { Item, MyUser, User } from "../../shared/graphql/graphql";
+import { Item, MyUser, User } from "shared/graphql/graphql";
 import { ItemWithParsedPayload } from "./types/ItemWithParsedPayload";
 import { HiddenIFrameForServiceWorker } from "./pushNotificationPreferences";
 import { GlobalStateProvider } from "./globalState";
@@ -35,10 +35,6 @@ import {
   TelemetryContext,
 } from "./types/Telemetry";
 import { IUserTelemetryEvent } from "@guardian/user-telemetry-client";
-import {
-  EXPAND_PINBOARD_QUERY_PARAM,
-  OPEN_PINBOARD_QUERY_PARAM,
-} from "../../shared/constants";
 import { UserLookup } from "./types/UserLookup";
 import {
   InlineMode,
@@ -49,7 +45,6 @@ import { getAgateFontFaceIfApplicable } from "../fontNormaliser";
 import { Global } from "@emotion/react";
 import { TourStateProvider } from "./tour/tourState";
 import { demoMentionableUsers, demoUser } from "./tour/tourConstants";
-import { readAndThenSilentlyDropQueryParamFromURL } from "./util";
 
 const PRESELECT_PINBOARD_HTML_TAG = "pinboard-preselect";
 const PRESET_UNREAD_NOTIFICATIONS_COUNT_HTML_TAG = "pinboard-bubble-preset";
@@ -73,25 +68,13 @@ export const PinBoardApp = ({
     HTMLElement[]
   >([]);
 
-  // using state here but without setter, because host application/SPA might change url
-  // and lose the query param, but we don't want to lose the preselection
-  const [openPinboardIdBasedOnQueryParam] = useState(
-    readAndThenSilentlyDropQueryParamFromURL(OPEN_PINBOARD_QUERY_PARAM)
-  );
-
   const [preSelectedComposerId, setPreselectedComposerId] = useState<
     string | null | undefined
   >(null);
 
   const [composerSection, setComposerSection] = useState<string | undefined>();
 
-  const [isExpanded, setIsExpanded] = useState<boolean>(
-    !!openPinboardIdBasedOnQueryParam || // expand by default when preselected via url query param
-      readAndThenSilentlyDropQueryParamFromURL(
-        EXPAND_PINBOARD_QUERY_PARAM
-      )?.toLowerCase() === "true"
-  );
-  const expandFloaty = () => setIsExpanded(true);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const refreshAssetHandleNodes = () =>
     setAssetHandles(
@@ -374,7 +357,6 @@ export const PinBoardApp = ({
           hasApolloAuthError={hasApolloAuthError}
           presetUnreadNotificationCount={presetUnreadNotificationCount}
           userEmail={userEmail}
-          openPinboardIdBasedOnQueryParam={openPinboardIdBasedOnQueryParam}
           preselectedComposerId={preSelectedComposerId}
           payloadToBeSent={payloadToBeSent}
           setPayloadToBeSent={setPayloadToBeSent}
@@ -443,7 +425,7 @@ export const PinBoardApp = ({
                 key={index}
                 node={node}
                 setPayloadToBeSent={setPayloadToBeSent}
-                expand={expandFloaty}
+                expand={() => setIsExpanded(true)}
               />
             ))}
           </TourStateProvider>


### PR DESCRIPTION
https://trello.com/c/X6CYyJxa/1623-fix

Noticed that the X button beside a pinboard which had been opened via query param (`?pinboardId=`) was doing nothing (until browser was refreshed). This was because the value is stored in state (necessary because it forms part of the 'activePinboards' list - even if its not strictly part of 'manuallyOpenedPinboardIds' list for the user - so that workflow details are loaded etc.) BUT this state was never cleared in the `closePinboard` function.

In the process centralised the logic around this (as well as the `expandPinboard` query param) into just globalState, for simplicity (or rather to avoid indirection).

### Testing
I've tested this locally.

You can...
- do the same (see README) then once running, visit https://pinboard.local.dev-gutools.co.uk/?pinboardId=65299 then see that the X button works
- or deploy to CODE (if it isn't already) and try https://composer.code.dev-gutools.co.uk/?pinboardId=65299 then see that the X button works

... in both cases once the pinboard has loaded, you'll need to click the <img width="51" alt="image" src="https://github.com/guardian/pinboard/assets/19289579/87629c03-7c37-460d-8e34-7ee9b745da45"> to get back to the view with 'My Pinboards'.