### PR TITLE
improve workflow integration

### DIFF
--- a/client/fontNormaliser.ts
+++ b/client/fontNormaliser.ts
@@ -18,15 +18,17 @@ const agateFontNameVariants = [
   "GuardianAgateSans1Web",
 ];
 
+export const agateFontFamily = `${agateFontNameVariants
+  .map((_) => `"${_}"`)
+  .join(",")}, Arial, sans-serif;`;
+
 // source foundations will give us Guardian Text Sans, but we usually want Guardian Agate Sans, so as to fit in with
 // the tools hosting pinboard.
 const overrideToAgateSans: FontOverride =
   (originalFunc: FontScaleFunctionStr) => (options?: FontScaleArgs) =>
     `
   ${originalFunc(options)};
-  font-family: ${agateFontNameVariants
-    .map((_) => `"${_}"`)
-    .join(",")}, Arial, sans-serif;
+  font-family: ${agateFontFamily};
 `;
 
 const defaultToPx: FontOverride =

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -68,6 +68,13 @@ export const PinBoardApp = ({
     HTMLElement[]
   >([]);
 
+  const [maybeInlineSelectedPinboardId, _setMaybeInlineSelectedPinboardId] =
+    useState<string | null>(null);
+  const setMaybeInlineSelectedPinboardId = (pinboardId: string | null) => {
+    _setMaybeInlineSelectedPinboardId(null); // trigger unmount first
+    setTimeout(() => _setMaybeInlineSelectedPinboardId(pinboardId), 1);
+  };
+
   const [preSelectedComposerId, setPreselectedComposerId] = useState<
     string | null | undefined
   >(null);
@@ -408,15 +415,24 @@ export const PinBoardApp = ({
               }}
             >
               <TickContext.Provider value={lastTickTimestamp}>
-                {useMemo(isInlineMode, []) ? (
+                <Floaty isDropTarget={isDropTarget} />
+                <Panel
+                  isDropTarget={isDropTarget}
+                  workflowPinboardElements={workflowPinboardElements}
+                  setMaybeInlineSelectedPinboardId={
+                    setMaybeInlineSelectedPinboardId
+                  }
+                />
+                {useMemo(isInlineMode, []) && (
                   <InlineMode
                     workflowPinboardElements={workflowPinboardElements}
+                    maybeInlineSelectedPinboardId={
+                      maybeInlineSelectedPinboardId
+                    }
+                    setMaybeInlineSelectedPinboardId={
+                      setMaybeInlineSelectedPinboardId
+                    }
                   />
-                ) : (
-                  <React.Fragment>
-                    <Floaty isDropTarget={isDropTarget} />
-                    <Panel isDropTarget={isDropTarget} />
-                  </React.Fragment>
                 )}
               </TickContext.Provider>
             </root.div>

--- a/client/src/feedback.tsx
+++ b/client/src/feedback.tsx
@@ -8,14 +8,22 @@ import UpChevron from "../icons/chevron-up.svg";
 import { agateSans } from "../fontNormaliser";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "./types/Telemetry";
 import { useTourProgress } from "./tour/tourState";
-import { isInlineMode } from "./inline/inlineMode";
+import { useGlobalStateContext } from "./globalState";
 
-export const Feedback = () => {
+interface FeedbackProps {
+  setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
+}
+export const Feedback = ({
+  setMaybeInlineSelectedPinboardId,
+}: FeedbackProps) => {
+  const { setIsExpanded } = useGlobalStateContext();
   const sendTelemetryEvent = useContext(TelemetryContext);
   const [isOpen, setIsOpen] = useState(false);
   const tourProgress = useTourProgress();
 
   const handleTourStart = () => {
+    setMaybeInlineSelectedPinboardId(null); // ensure inlineModePanel is closed when tour starts to avoid confusion
+    setIsExpanded(true); // ensures pinboard is expanded when opened from inlineModePanel
     tourProgress.start();
     sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
       tourEvent: "start_tour",
@@ -173,7 +181,7 @@ export const Feedback = () => {
             />
           </div>
         )}
-        {!tourProgress.isRunning && !isInlineMode() && (
+        {!tourProgress.isRunning && (
           <div
             css={css`
               color: white;

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -104,6 +104,7 @@ export const InlineMode = ({
             closePanel={() => setMaybeInlineSelectedPinboardId(null)}
             workingTitle={maybeSelectedNode.dataset.workingTitle || null}
             headline={maybeSelectedNode.dataset.headline || null}
+            setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
           />,
           pinboardArea
         )}

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -13,26 +13,41 @@ export const WORKFLOW_PINBOARD_ELEMENTS_QUERY_SELECTOR =
 export const isInlineMode = () =>
   window.location.hostname.startsWith("workflow.");
 
+const getPinboardColumnHeadingElement = () =>
+  document.querySelector(".content-list-head__heading--pinboard");
+export const isPinboardColumnTurnedOn = () =>
+  !!getPinboardColumnHeadingElement();
+
+export const getWorkflowTitleElementLookup = (
+  workflowPinboardElements: HTMLElement[]
+) =>
+  workflowPinboardElements.reduce((acc, node) => {
+    const { pinboardId } = node.dataset;
+    return pinboardId ? { ...acc, [pinboardId]: node } : acc;
+  }, {} as Record<string, HTMLElement>);
+
 interface InlineModeProps {
   workflowPinboardElements: HTMLElement[];
+  maybeInlineSelectedPinboardId: string | null;
+  setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
 }
 
-export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
+export const InlineMode = ({
+  workflowPinboardElements,
+  maybeInlineSelectedPinboardId,
+  setMaybeInlineSelectedPinboardId,
+}: InlineModeProps) => {
   const pinboardArea = useMemo(
     () => document.getElementById("pinboard-area"),
     []
   );
   const pinboardColumnHeadingElement = useMemo(
-    () => document.querySelector(".content-list-head__heading--pinboard"),
+    getPinboardColumnHeadingElement,
     []
   );
 
   const workflowTitleElementLookup = useMemo(
-    () =>
-      workflowPinboardElements.reduce((acc, node) => {
-        const { pinboardId } = node.dataset;
-        return pinboardId ? { ...acc, [pinboardId]: node } : acc;
-      }, {} as Record<string, HTMLElement>),
+    () => getWorkflowTitleElementLookup(workflowPinboardElements),
     [workflowPinboardElements]
   );
 
@@ -69,13 +84,9 @@ export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
     }
   }, [workflowTitleElementLookup]);
 
-  const [maybeSelectedPinboardId, setMaybeSelectedPinboardId] = useState<
-    string | null
-  >(null);
-
   const maybeSelectedNode =
-    maybeSelectedPinboardId &&
-    workflowTitleElementLookup[maybeSelectedPinboardId];
+    maybeInlineSelectedPinboardId &&
+    workflowTitleElementLookup[maybeInlineSelectedPinboardId];
 
   return (
     <React.Fragment>
@@ -88,9 +99,9 @@ export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
         pinboardArea &&
         ReactDOM.createPortal(
           <InlineModePanel
-            pinboardId={maybeSelectedPinboardId}
+            pinboardId={maybeInlineSelectedPinboardId}
             composerId={maybeSelectedNode.dataset.composerId || null}
-            closePanel={() => setMaybeSelectedPinboardId(null)}
+            closePanel={() => setMaybeInlineSelectedPinboardId(null)}
             workingTitle={maybeSelectedNode.dataset.workingTitle || null}
             headline={maybeSelectedNode.dataset.headline || null}
           />,
@@ -103,11 +114,8 @@ export const InlineMode = ({ workflowPinboardElements }: InlineModeProps) => {
             node={node}
             pinboardId={pinboardId}
             counts={itemCountsLookup[pinboardId]}
-            isSelected={pinboardId === maybeSelectedPinboardId}
-            setMaybeSelectedPinboardId={(pinboardId: string | null) => {
-              setMaybeSelectedPinboardId(null); // trigger unmount first
-              setTimeout(() => setMaybeSelectedPinboardId(pinboardId), 1);
-            }}
+            isSelected={pinboardId === maybeInlineSelectedPinboardId}
+            setMaybeSelectedPinboardId={setMaybeInlineSelectedPinboardId}
           />
         )
       )}

--- a/client/src/inline/inlineModePanel.tsx
+++ b/client/src/inline/inlineModePanel.tsx
@@ -18,6 +18,7 @@ interface InlineModePanelProps {
   closePanel: () => void;
   workingTitle: string | null;
   headline: string | null;
+  setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
 }
 
 export const InlineModePanel = ({
@@ -26,6 +27,7 @@ export const InlineModePanel = ({
   closePanel,
   workingTitle,
   headline,
+  setMaybeInlineSelectedPinboardId,
 }: InlineModePanelProps) => {
   const { hasError, activeTab, setActiveTab } = useGlobalStateContext();
 
@@ -91,6 +93,7 @@ export const InlineModePanel = ({
           isSelected
           isExpanded
           panelElement={panelRef.current}
+          setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
         />
       </div>
     </root.div>

--- a/client/src/inline/workflowColumnInstructions.tsx
+++ b/client/src/inline/workflowColumnInstructions.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { css } from "@emotion/react";
+import { composer } from "../../colours";
+import { palette, space } from "@guardian/source-foundations";
+import { agateSans } from "../../fontNormaliser";
+import { SvgAlertTriangle } from "@guardian/source-react-components";
+
+const enableWorkflowColumnAndReload = () => {
+  const pinboardColumnCheckbox = document.querySelector<HTMLInputElement>(
+    "#pinboard.column-configurator__label"
+  );
+  if (pinboardColumnCheckbox) {
+    if (pinboardColumnCheckbox.checked) {
+      pinboardColumnCheckbox.click(); // uncheck first if needs be
+    }
+    pinboardColumnCheckbox.click(); // click() rather than assigning checked=true, to ensure 'apply_column_changes' becomes enabled
+  } else {
+    alert(
+      "Could not find pinboard column checkbox. Please add the Pinboard column manually."
+    );
+  }
+  const applyChangesButton = document.getElementById("apply_column_changes");
+  if (applyChangesButton) {
+    applyChangesButton.click();
+  } else {
+    alert(
+      "Could not find apply column changes button. Please add the Pinboard column manually."
+    );
+  }
+};
+export const WorkflowColumnInstructions = () => (
+  <div
+    css={css`
+      background-color: ${composer.warning[100]};
+      color: ${palette.neutral[100]};
+      ${agateSans.xsmall({ lineHeight: "tight", fontWeight: "bold" })}
+      padding: ${space[2]}px;
+      border-radius: ${space[1]}px;
+      margin: ${space[1]}px;
+      position: relative;
+      top: 0;
+      z-index: 99;
+    `}
+  >
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        column-gap: ${space[2]}px;
+      `}
+    >
+      <div
+        css={css`
+          fill: ${palette.neutral[100]};
+        `}
+      >
+        <SvgAlertTriangle size="small" />
+      </div>
+      <div>
+        It is <strong>strongly</strong> recommended that you enable the Pinboard
+        column in workflow.
+        <button
+          css={css`
+            ${agateSans.xsmall({ lineHeight: "tight", fontWeight: "bold" })};
+            margin-top: ${space[1]}px;
+            padding: ${space[1]}px ${space[2]}px;
+            color: ${palette.neutral[100]};
+            border: 1px solid ${composer.warning[300]};
+            border-radius: ${space[1]}px;
+            background-color: transparent;
+            &:hover {
+              background-color: ${composer.warning[300]};
+            }
+            cursor: pointer;
+          `}
+          onClick={enableWorkflowColumnAndReload}
+        >
+          ENABLE COLUMN NOW
+        </button>
+      </div>
+    </div>
+  </div>
+);

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -28,6 +28,7 @@ import { ErrorOverlay } from "./errorOverlay";
 import { Tour } from "./tour/tour";
 import { useTourProgress } from "./tour/tourState";
 import { demoPinboardsWithClaimCounts } from "./tour/tourConstants";
+import { isInlineMode } from "./inline/inlineMode";
 
 const teamPinboardsSortFunction = (
   a: PinboardIdWithClaimCounts,
@@ -45,7 +46,16 @@ const teamPinboardsSortFunction = (
   );
 };
 
-export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
+interface PanelProps extends IsDropTargetProps {
+  workflowPinboardElements: HTMLElement[];
+  setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
+}
+
+export const Panel: React.FC<PanelProps> = ({
+  isDropTarget,
+  workflowPinboardElements,
+  setMaybeInlineSelectedPinboardId,
+}) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const {
     hasError,
@@ -62,14 +72,15 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
 
   const tourProgress = useTourProgress();
 
+  const isInline = useMemo(isInlineMode, []);
+
   const selectedPinboard = activePinboards.find(
     (activePinboard) => activePinboard.id === selectedPinboardId
   );
   const [_maybePeekingAtPinboard, setMaybePeekingAtPinboard] =
     useState<PinboardData | null>(null);
-  const maybePeekingAtPinboard = tourProgress.isRunning
-    ? null
-    : _maybePeekingAtPinboard;
+  const maybePeekingAtPinboard =
+    tourProgress.isRunning || isInline ? null : _maybePeekingAtPinboard;
 
   const title = (() => {
     if (selectedPinboard?.isNotFound) {
@@ -276,6 +287,8 @@ export const Panel: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
           noOfTeamPinboardsNotShown={noOfTeamPinboardsNotShown}
           isShowAllTeamPinboards={isShowAllTeamPinboards}
           setIsShowAllTeamPinboards={setIsShowAllTeamPinboards}
+          workflowPinboardElements={workflowPinboardElements}
+          setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
         />
       )}
 

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -310,6 +310,7 @@ export const Panel: React.FC<PanelProps> = ({
             isExpanded={pinboardId === selectedPinboardId && isExpanded}
             isSelected={pinboardId === selectedPinboardId}
             panelElement={panelRef.current}
+            setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
           />
         ))
       }
@@ -321,6 +322,7 @@ export const Panel: React.FC<PanelProps> = ({
           isExpanded={isExpanded}
           isSelected={true}
           panelElement={panelRef.current}
+          setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
         />
       )}
     </div>

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -35,6 +35,7 @@ interface PinboardProps {
   isExpanded: boolean;
   isSelected: boolean;
   panelElement: HTMLDivElement | null;
+  setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
 }
 
 export const Pinboard: React.FC<PinboardProps> = ({
@@ -43,6 +44,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
   isExpanded,
   isSelected,
   panelElement,
+  setMaybeInlineSelectedPinboardId,
 }) => {
   const {
     hasBrowserFocus,
@@ -331,7 +333,9 @@ export const Pinboard: React.FC<PinboardProps> = ({
       <div>{maybeDeleteItemModalElement}</div>
       <div>{maybeEditingItemId && <ModalBackground />}</div>
       <div ref={useTourStepRef("feedback")}>
-        <Feedback />
+        <Feedback
+          setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
+        />
       </div>
       {initialItemsQuery.loading && "Loading..."}
       <div // push chat messages to bottom of panel if they do not fill

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -407,7 +407,9 @@ export const SelectPinboard = ({
           outline: "none",
         }}
       >
-        <Feedback />
+        <Feedback
+          setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
+        />
         {isInline && !hasPinboardColumn && <WorkflowColumnInstructions />}
         {preselectedPinboard === "notTrackedInWorkflow" && (
           <NotTrackedInWorkflow />

--- a/client/src/tour/tooltip.tsx
+++ b/client/src/tour/tooltip.tsx
@@ -5,11 +5,12 @@ import { composer } from "../../colours";
 import { tourStepIDs } from "./tourStepMap";
 import { SvgCross } from "@guardian/source-react-components";
 import root from "react-shadow/emotion";
+import { agateFontFamily } from "../../fontNormaliser";
 
 export const tourButtonStyles = {
   display: "flex",
   alignItems: "flex-start",
-  fontFamily: "Guardian Agate Sans",
+  fontFamily: agateFontFamily,
   border: `${composer.primary[300]} 1px solid`,
   borderRadius: `${space[1]}px`,
   fontSize: `${space[3]}px`,
@@ -67,7 +68,7 @@ export const Tooltip = ({
   <root.div
     {...tooltipProps}
     style={{
-      fontFamily: "Guardian Agate Sans",
+      fontFamily: agateFontFamily,
       fontSize: 15,
       padding: `${space[2]}px ${space[3]}px ${space[3]}px`,
       width: 253,

--- a/client/src/tour/tourState.tsx
+++ b/client/src/tour/tourState.tsx
@@ -243,9 +243,11 @@ export const TourStateProvider: React.FC = ({ children }) => {
       sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {
         tourEvent: "complete_tour",
       });
+      clearSelectedPinboard();
     } else if (action === ACTIONS.CLOSE) {
       setTourState({ isRunning: false, stepIndex: -1 });
       !hasEverUsedTour && visitTourStep("DISMISSED");
+      clearSelectedPinboard();
 
       lifecycle === LIFECYCLE.COMPLETE && // Prevent 'CLOSE' action being logged multiple times
         sendTelemetryEvent?.(PINBOARD_TELEMETRY_TYPE.INTERACTIVE_TOUR, {


### PR DESCRIPTION
https://trello.com/c/Pw4EGPHn/1660-improve-pinboard-workflow-integration

Facilitated by https://github.com/guardian/workflow-frontend/pull/404

Previously pinboard integration in workflow was just an optional column displayed to permissioned users with an 'inline mode' for displaying the pinboard for the relevant row in workflow, introduced in #219 ). However we've had multiple bits of user feedback from users who spend lots of time in workflow, that they were missing unread messages from pinboards not displayed in workflow given their set of filters (e.g. an unrelated board in 'my pinboards').

This PR makes the floaty and panel display always in workflow (for permissioned users, facilitated by https://github.com/guardian/workflow-frontend/pull/404) but with some key tweaks to the SelectPinboard view, so that clicking a pinboard in `My Pinboards` or `My Teams' Pinboards` will...

- scroll to the relevant row in workflow and open the 'inline mode panel' for that pinboard IF the row is visible given current workflow filters
- ELSE open in a new tab to avoid confusion

... this solution represents a compromise of familiarity for users and simplicity of implementation whilst minimising the confusion that could arise from the regular Pinboard floaty/panel displaying the same items as displayed in workflow.

Given we now display the floaty all the time, there's now a warning about the column not being enabled with a handy button to enable the column (implemented by driving the underlying workflow interface 😈).

Also, this has meant we could re-instate the interactive demo in workflow (previously disabled because no floaty and so no SelectPinboard view so didn't make sense), which required a few tweaks (see relevant commit).

![improved_workflow](https://github.com/guardian/pinboard/assets/19289579/926b0942-0c60-4726-b265-ccd7cc407b52)
