### PR TITLE
Rewrite React.fc<type> props declarations

### DIFF
--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -7,11 +7,11 @@ import { PayloadDisplay } from "./payloadDisplay";
 import { buildPayloadAndType, PayloadAndType } from "./types/PayloadAndType";
 import * as Sentry from "@sentry/react";
 
-interface AssetView {
+interface AssetViewProps {
   items: Item[];
 }
 
-export const AssetView: React.FC<AssetView> = ({ items }) => {
+export const AssetView = ({ items }: AssetViewProps) => {
   const payloadsMap: PayloadAndType[] = items
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
     .reduce<PayloadAndType[]>((accumulator, item) => {

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -39,7 +39,7 @@ const FloatyNotificationsBubble = ({
   </div>
 );
 
-export const Floaty: React.FC<IsDropTargetProps> = ({ isDropTarget }) => {
+export const Floaty = ({ isDropTarget }: IsDropTargetProps) => {
   const {
     presetUnreadNotificationCount,
     isExpanded,

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -4,7 +4,13 @@ import {
   useMutation,
   useQuery,
 } from "@apollo/client";
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, {
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { Item, MyUser } from "../../shared/graphql/graphql";
 import {
   gqlAddManuallyOpenedPinboardIds,
@@ -124,8 +130,10 @@ interface GlobalStateProviderProps {
   presetUnreadNotificationCount: number | undefined;
   hasEverUsedTour: boolean | undefined;
   visitTourStep: (tourStepId: string) => void;
+  children: ReactNode;
 }
-export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
+
+export const GlobalStateProvider = ({
   hasApolloAuthError,
   userEmail,
   preselectedComposerId,
@@ -144,7 +152,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   hasEverUsedTour,
   visitTourStep,
   children,
-}) => {
+}: GlobalStateProviderProps) => {
   const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
 
   useEffect(() => {

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -5,7 +5,7 @@ import {
   useQuery,
 } from "@apollo/client";
 import React, {
-  ReactNode,
+  PropsWithChildren,
   useCallback,
   useContext,
   useEffect,
@@ -130,7 +130,6 @@ interface GlobalStateProviderProps {
   presetUnreadNotificationCount: number | undefined;
   hasEverUsedTour: boolean | undefined;
   visitTourStep: (tourStepId: string) => void;
-  children: ReactNode;
 }
 
 export const GlobalStateProvider = ({
@@ -152,7 +151,7 @@ export const GlobalStateProvider = ({
   hasEverUsedTour,
   visitTourStep,
   children,
-}: GlobalStateProviderProps) => {
+}: PropsWithChildren<GlobalStateProviderProps>) => {
   const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
 
   useEffect(() => {

--- a/client/src/navigation/button.tsx
+++ b/client/src/navigation/button.tsx
@@ -25,13 +25,13 @@ interface NavButtonProps {
   unreadCount?: number | null;
   title?: string;
 }
-export const NavButton: React.FC<NavButtonProps> = ({
+export const NavButton = ({
   onClick,
   icon: Icon,
   hoverParent,
   unreadCount,
   title,
-}) => (
+}: NavButtonProps) => (
   <span
     title={title}
     onClick={onClick}

--- a/client/src/navigation/tabs.tsx
+++ b/client/src/navigation/tabs.tsx
@@ -11,11 +11,12 @@ interface TabsProps {
   setActiveTab: (tab: Tab) => void;
   unreadMessages: number | null;
 }
-export const Tabs: React.FC<TabsProps> = ({
+
+export const Tabs = ({
   activeTab,
   setActiveTab,
   unreadMessages,
-}) => (
+}: TabsProps) => (
   <div
     css={css`
       display: flex;

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -51,11 +51,11 @@ interface PanelProps extends IsDropTargetProps {
   setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
 }
 
-export const Panel: React.FC<PanelProps> = ({
+export const Panel = ({
   isDropTarget,
   workflowPinboardElements,
   setMaybeInlineSelectedPinboardId,
-}) => {
+}: PanelProps) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const {
     hasError,

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -45,7 +45,7 @@ export const Pinboard = ({
   isSelected,
   panelElement,
   setMaybeInlineSelectedPinboardId,
-}) => {
+}: PinboardProps) => {
   const {
     hasBrowserFocus,
 

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -38,7 +38,7 @@ interface PinboardProps {
   setMaybeInlineSelectedPinboardId: (pinboardId: string | null) => void;
 }
 
-export const Pinboard: React.FC<PinboardProps> = ({
+export const Pinboard = ({
   pinboardId,
   composerId,
   isExpanded,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As suggested in https://github.com/guardian/pinboard/pull/295#discussion_r1309051825, this rewrites various props declarations from:
`export const AssetView: React.FC<AssetView> = ({ items }) => {...}`
to: 
`export const AssetView = ({ items }: AssetViewProps) => {...}`

Functionally this is the same, but this seems like a nicer way to write it. 


## How to test

Since this is a small code style refactor, the project should still compile and intellisense in vscode or intellij should keep picking up on types for the specified props:

![image](https://github.com/guardian/pinboard/assets/102960844/6b52e214-81bc-4fa4-aea0-96761d69f979)