### PR TITLE
improve group mention autocomplete

### DIFF
--- a/database-bridge-lambda/src/sql/User.ts
+++ b/database-bridge-lambda/src/sql/User.ts
@@ -26,7 +26,7 @@ export const searchMentionableUsers = async (
         AND "GroupMember"."userGoogleID" = "User"."googleID"
         ), '[]') AS "memberEmails"
     FROM "Group"
-    WHERE "shorthand" ILIKE ${args.prefix + "%"}
+    WHERE "shorthand" ILIKE ${"%" + args.prefix + "%"}
     OR "name" ILIKE ${"%" + args.prefix + "%"}
     OR "primaryEmail" ILIKE ${"%" + args.prefix + "%"}
     OR EXISTS(


### PR DESCRIPTION
When demoing with @MaxWalker2010 we noticed that the mentions autocomplete wasn't for example showing `Features PicDesk` when typing `pic`.

The match on `shorthand` for the group was 'starts with' rather than 'contains'. This PR makes it a 'contains' like the matches on name, email etc.

✅  TESTED in `CODE`