### PR TITLE
support soft-breaks in messages 

### DIFF
--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -251,7 +251,13 @@ export const ItemDisplay = ({
                       userLookup,
                     ]
                   )}
-                {formattedMessage}
+                <span
+                  css={css`
+                    white-space: pre-line;
+                  `}
+                >
+                  {formattedMessage}
+                </span>
               </>
             )}
           </div>

--- a/client/src/itemInputBox.tsx
+++ b/client/src/itemInputBox.tsx
@@ -100,8 +100,10 @@ const Suggestion = ({
   </div>
 );
 
-const isEnterKey = (event: React.KeyboardEvent<HTMLElement>) =>
-  event.key === "Enter" || event.keyCode === 13;
+const isHardReturn = (event: React.KeyboardEvent<HTMLElement>) =>
+  (event.key === "Enter" || event.keyCode === 13) &&
+  !event.shiftKey &&
+  !event.altKey;
 
 const hostname = window?.location.hostname || ".test.";
 const gridDomain =
@@ -292,7 +294,7 @@ export const ItemInputBox = ({
           sendItem &&
           ((event) => {
             event.stopPropagation();
-            if (isEnterKey(event)) {
+            if (isHardReturn(event)) {
               if (!isAsGridPayloadLoading && (message || payloadToBeSent)) {
                 sendItem();
               }


### PR DESCRIPTION
Legit request from user...

> How about allowing soft returns in the typing box so you can separate different queries or put in the relevant quote without running on? A soft return currently means "send".

I will push back on the first example usage of soft breaks and encourage separate queries to intentionally be different messages, so they can be 'replied' to (see https://github.com/guardian/pinboard/pull/277). 

So this PR...

- detects shift/alt when pressing Enter key and doesn't send accordingly (allowing the default behaviour of soft line break)
- respect line breaks when rendering (with `white-space: pre-line`)

![soft](https://github.com/guardian/pinboard/assets/19289579/078aaf89-2974-49bb-97c3-13dd5aad57ee)
