### PR TITLE
Add devx-backup tag to database

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -617,6 +617,10 @@ Object {
         "StorageType": "gp2",
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -721,6 +725,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -751,6 +759,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -939,6 +951,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -1044,6 +1060,10 @@ Object {
           "Ref": "pinboardPrivateSubnets",
         },
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -1989,6 +2009,10 @@ Object {
           "SecretStringTemplate": "{\\"username\\":\\"pinboard\\"}",
         },
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -18,6 +18,7 @@ import {
   Fn,
   RemovalPolicy,
   Stack,
+  Tags,
 } from "aws-cdk-lib";
 import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import { join } from "path";
@@ -110,6 +111,7 @@ export class PinBoardStack extends GuStack {
       publiclyAccessible: false,
       removalPolicy: RemovalPolicy.RETAIN,
     });
+    Tags.of(database).add("devx-backup-enabled", "true");
 
     const roleToInvokeLambdaFromRDS = new iam.Role(
       this,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Part of [RDS Backups](https://trello.com/c/ZQ2cQWQD/2032-rds-backups-devx-pairing) 

Enables more robust backup processes powered by AWS backup service for the RDS database, as per this [FAQ](https://docs.google.com/document/d/1VDCSxYFlWs4R6g0Waa6OmmfytV60AROyHxfIGho7cLA/edit#heading=h.vwt7syo8ng40).

## How to test

This was added to code, and we could verify this successfully enabled the desired backup in the AWS console. 

