### PR TITLE
Tag RDS instance only

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -617,6 +617,10 @@ Object {
         "StorageType": "gp2",
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -721,6 +725,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -751,6 +759,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -939,6 +951,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -1044,6 +1060,10 @@ Object {
           "Ref": "pinboardPrivateSubnets",
         },
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -1989,6 +2009,10 @@ Object {
           "SecretStringTemplate": "{\\"username\\":\\"pinboard\\"}",
         },
         "Tags": Array [
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",

--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -725,10 +725,6 @@ Object {
         },
         "Tags": Array [
           Object {
-            "Key": "devx-backup-enabled",
-            "Value": "true",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -759,10 +755,6 @@ Object {
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "devx-backup-enabled",
-            "Value": "true",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -951,10 +943,6 @@ Object {
         ],
         "Tags": Array [
           Object {
-            "Key": "devx-backup-enabled",
-            "Value": "true",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
           },
@@ -1060,10 +1048,6 @@ Object {
           "Ref": "pinboardPrivateSubnets",
         },
         "Tags": Array [
-          Object {
-            "Key": "devx-backup-enabled",
-            "Value": "true",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",
@@ -2009,10 +1993,6 @@ Object {
           "SecretStringTemplate": "{\\"username\\":\\"pinboard\\"}",
         },
         "Tags": Array [
-          Object {
-            "Key": "devx-backup-enabled",
-            "Value": "true",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "49.5.0",

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -18,6 +18,7 @@ import {
   Fn,
   RemovalPolicy,
   Stack,
+  Tags,
 } from "aws-cdk-lib";
 import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import { join } from "path";
@@ -110,6 +111,7 @@ export class PinBoardStack extends GuStack {
       publiclyAccessible: false,
       removalPolicy: RemovalPolicy.RETAIN,
     });
+    Tags.of(database).add("devx-backup-enabled", "true");
 
     const roleToInvokeLambdaFromRDS = new iam.Role(
       this,

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -111,7 +111,8 @@ export class PinBoardStack extends GuStack {
       publiclyAccessible: false,
       removalPolicy: RemovalPolicy.RETAIN,
     });
-    Tags.of(database).add("devx-backup-enabled", "true");
+    const cfnDbInstance = database.node.defaultChild as rds.CfnDBInstance;
+    Tags.of(cfnDbInstance).add("devx-backup-enabled", "true");
 
     const roleToInvokeLambdaFromRDS = new iam.Role(
       this,
@@ -123,7 +124,7 @@ export class PinBoardStack extends GuStack {
       }
     );
 
-    (database.node.defaultChild as rds.CfnDBInstance).associatedRoles = [
+    cfnDbInstance.associatedRoles = [
       {
         featureName: "Lambda",
         roleArn: roleToInvokeLambdaFromRDS.roleArn,


### PR DESCRIPTION
Example of accessing AWS::RDS::DBInstance for tagging (doesn't need to be merged - just raising this to explain a comment [here](https://github.com/guardian/pinboard/pull/301#pullrequestreview-1844095277)).