### PR TITLE
💸 decrease polling frequency of `getGroupPinboardIds` and `getItemCounts` from 5s to 15s 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -80,7 +80,7 @@ export const InlineMode = ({
             )
           ),
       });
-      startPolling(5000);
+      startPolling(15000);
     }
   }, [workflowTitleElementLookup]);
 

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -105,7 +105,7 @@ export const Panel = ({
     Math.abs(boundedPositionTranslation.y) > window.innerHeight / 2;
 
   const groupPinboardIdsQuery = useQuery(gqlGetGroupPinboardIds, {
-    pollInterval: 5000, // always poll this one, to ensure we get unread flags even when pinboard is not expanded
+    pollInterval: 15000, // always poll this one, to ensure we get unread flags even when pinboard is not expanded
   });
 
   const groupPinboardIdsWithClaimCounts: PinboardIdWithClaimCounts[] = useMemo(


### PR DESCRIPTION
…as they're quite expensive (and also a bit annoying in the Network tab of the Dev Tools when debugging composer, grid, workflow etc.)

This is hopefully a temporary measure that I'd like to replace with GraphQL subscriptions somehow, so they're realtime like everything else - but this is not straight forward given it requires a DB query to determine who's impacted by a change in a group mention, which can't be done directly in the mutation (so would need to be triggered as follow-up task... i.e. complexity).

## Detail
`EU-GraphQLInvocation` makes up the majority of the cost of pinboard...

<img width="941" alt="image" src="https://github.com/guardian/pinboard/assets/19289579/d0e64629-84c4-4c94-89b7-f7ad46ceb0fb">

... and using enhanced metrics in AppSync we can see that `getGroupPinboardIds` and `getItemCounts` are the two big hitters (making up 85% and 12% respectively) , since they're polled every 5s even when pinboard is collapsed, so essentially while every user has composer, grid, MAM or workflow open...

<img width="1411" alt="image" src="https://github.com/guardian/pinboard/assets/19289579/0511696b-c007-41ba-824e-b7e6c44cceb4">

... so by decreasing the polling frequency from 5s to 15s, we should expect to see AppSync cost fall from approx $15 a day to $5. So whilst not efficient as it could be with a subscription-based approach, **it does represent savings of $3,650 per year**... which can start the moment this PR is merged 🙏 