### PR TITLE
export `bootstrapping-lambda`'s function name as CfnOutput

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -29,6 +29,15 @@ Object {
     "gu:cdk:version": "49.5.0",
   },
   "Outputs": Object {
+    "BootstrappingLambdaFunctionName": Object {
+      "Description": "pinboard-bootstrapping-lambda-TEST function name",
+      "Export": Object {
+        "Name": "pinboard-bootstrapping-lambda-TEST-function-name",
+      },
+      "Value": Object {
+        "Ref": "pinboardbootstrappinglambdaD2C487DA",
+      },
+    },
     "pinboardbootstrappinglambdaapiEndpoint4DE1E032": Object {
       "Value": Object {
         "Fn::Join": Array [

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -635,6 +635,7 @@ export class PinBoardStack extends GuStack {
 
     const bootstrappingLambdaBasename = "pinboard-bootstrapping-lambda";
     const bootstrappingLambdaApiBaseName = `${bootstrappingLambdaBasename}-api`;
+    const bootstrappingLambdaFunctionName = `${bootstrappingLambdaBasename}-${this.stage}`;
 
     const bootstrappingLambdaFunction = new lambda.Function(
       this,
@@ -656,7 +657,7 @@ export class PinBoardStack extends GuStack {
               "/pinboard/sentryDSN"
             ),
         },
-        functionName: `${bootstrappingLambdaBasename}-${this.stage}`,
+        functionName: bootstrappingLambdaFunctionName,
         code: lambda.Code.fromBucket(
           deployBucket,
           `${this.stack}/${this.stage}/${bootstrappingLambdaApiBaseName}/${bootstrappingLambdaApiBaseName}.zip`
@@ -730,6 +731,12 @@ export class PinBoardStack extends GuStack {
     new CfnOutput(this, `${bootstrappingLambdaApiBaseName}-hostname`, {
       description: `${bootstrappingLambdaApiBaseName}-hostname`,
       value: `${bootstrappingApiDomainName.domainNameAliasDomainName}`,
+    });
+
+    new CfnOutput(this, `BootstrappingLambdaFunctionName`, {
+      exportName: `${bootstrappingLambdaFunctionName}-function-name`,
+      description: `${bootstrappingLambdaFunctionName} function name`,
+      value: `${bootstrappingLambdaFunction.functionName}`,
     });
   }
 }


### PR DESCRIPTION
Once a CfnOutput is in use by another cloudformation stack then it can't be un-cloudformed. Since the CfnOutput of the  `bootstrapping-lambda`'s function name is in use in CODE (as part of https://github.com/guardian/pinboard/pull/226 / https://github.com/guardian/octopus/pull/3) I was forced to chain https://github.com/guardian/pinboard/pull/312 on the end for speed whilst developing... now is the time to untangle. 

SO, I've extracted this change as a prerequisite, I will then rebase the following onto it (rather than onto each other)...
- https://github.com/guardian/pinboard/pull/226 (which will remain very much a WIP)
- https://github.com/guardian/pinboard/pull/312 (so we can be ready to review/merge in the coming days/weeks)