### PR TITLE
fix husky `pre-commit` hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,14 @@
 #!/bin/sh
+echo "Running pre-commit hook"
+
 . "$(dirname "$0")/_/husky.sh"
 
 set -e
+
+fnm use
+
+fnm use || true
+nvm use || true
 
 corepack enable
 yarn lint-staged


### PR DESCRIPTION
run `fnm use` and `nvm use` to ensure correct version of node before executing the various steps in the `pre-commit` hook (configured via husky)

Broken since #307 