### PR TITLE
add alarm for `bootstrapping-lambda` API gateway 5XXs

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -26,6 +26,7 @@ Object {
       "GuCname",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "59.5.6",
   },
@@ -3881,6 +3882,85 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
+    },
+    "pinboardbootstrappinglambdaapiAlarmC961CA44": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The pinboard-bootstrapping-lambda-api-TEST gateway is experiencing 5XX errors",
+        "AlarmName": "pinboard-bootstrapping-lambda-api-TEST 5XX errors",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "pinboard-bootstrapping-lambda-api-TEST",
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Average",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "59.5.6",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "workflow",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 0.05,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "pinboardbootstrappinglambdaapiCloudWatchRole71E5177D": Object {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -19,6 +19,7 @@ import {
   RemovalPolicy,
   Stack,
   Tags,
+  Size,
 } from "aws-cdk-lib";
 import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import { join } from "path";
@@ -701,7 +702,7 @@ export class PinBoardStack extends GuStack {
         deployOptions: {
           stageName: "api",
         },
-        minimumCompressionSize: 0, // gzip responses where the client (i.e. browser) supports it (via 'Accept-Encoding' header)
+        minCompressionSize: Size.bytes(0), // gzip responses where the client (i.e. browser) supports it (via 'Accept-Encoding' header)
       }
     );
 

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -679,11 +679,12 @@ export class PinBoardStack extends GuStack {
       }
     );
 
+    const bootstrappingApiGatewayName = `${bootstrappingLambdaApiBaseName}-${this.stage}`;
     const bootstrappingApiGateway = new apiGateway.LambdaRestApi(
       this,
       bootstrappingLambdaApiBaseName,
       {
-        restApiName: `${bootstrappingLambdaApiBaseName}-${this.stage}`,
+        restApiName: bootstrappingApiGatewayName,
         handler: bootstrappingLambdaFunction,
         endpointTypes: [apiGateway.EndpointType.REGIONAL],
         policy: new iam.PolicyDocument({
@@ -705,6 +706,25 @@ export class PinBoardStack extends GuStack {
         minCompressionSize: Size.bytes(0), // gzip responses where the client (i.e. browser) supports it (via 'Accept-Encoding' header)
       }
     );
+    new GuAlarm(this, `${bootstrappingLambdaApiBaseName}Alarm`, {
+      app: APP,
+      snsTopicName: ALARM_SNS_TOPIC_NAME,
+      alarmName: `${bootstrappingApiGatewayName} 5XX errors`,
+      alarmDescription: `The ${bootstrappingApiGatewayName} gateway is experiencing 5XX errors`,
+      metric: new cloudwatch.Metric({
+        metricName: "5XXError",
+        namespace: "AWS/ApiGateway",
+        dimensionsMap: {
+          ApiName: bootstrappingApiGatewayName,
+        },
+        period: Duration.minutes(5),
+      }),
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      threshold: 0.05,
+      evaluationPeriods: 2,
+      actionsEnabled: true,
+      okAction: true,
+    });
 
     const bootstrappingApiCertificate = new acm.Certificate(
       this,


### PR DESCRIPTION
Since #315 we saw increased latency and 5XX from the bootstrapping-lambda (& its API Gateway) such that pinboard loaded flakily/intermittently for users. #315 was live for a few days (albeit mainly the weekend) before users reported their pin not being there, we should really have known via alarms - so this PR adds a 5XX alarm for the API gateway.