### PR TITLE
increase bootstrapping-lambda from 128MB to 256MB

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -3554,7 +3554,7 @@ $util.toJson($ctx.result)",
         },
         "FunctionName": "pinboard-bootstrapping-lambda-TEST",
         "Handler": "index.handler",
-        "MemorySize": 128,
+        "MemorySize": 256,
         "Role": Object {
           "Fn::GetAtt": Array [
             "pinboardbootstrappinglambdaServiceRoleE9E1278C",

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -643,7 +643,7 @@ export class PinBoardStack extends GuStack {
       bootstrappingLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
-        memorySize: 128,
+        memorySize: 256,
         timeout: Duration.seconds(5),
         handler: "index.handler",
         environment: {


### PR DESCRIPTION
The node20 upgrade in #315 introduced some instability in bootstrapping-lambda, and whilst #317 was a worthy upgrade of a deprecated package it didn't fix the problems as hoped. 

In CODE after hammering `/pinboard.loader.js` I was able to replicate the issues, and then after some reading, experimented with increasing memory (as that also proportionally increases CPU) and which made a decent reduction on duration and haven't yet been able to replicate the issues, so in this PR I codify the change so we can try out in PROD (it still might not fix things if it's a memory leak it might just take longer to manifest but worth a try nonetheless).