### PR TITLE
change all lambdas to use ARM architecture (i.e. graviton)

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -113,6 +113,9 @@ Object {
         "ArchiverLambdaServiceRoleEAB58FB0",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
@@ -1298,6 +1301,9 @@ Object {
         "EmailLambdaServiceRoleCBE95916",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
@@ -3392,6 +3398,9 @@ $util.toJson($ctx.result)",
         "pinboardauthlambdaServiceRole8197EA98",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-auth-lambda/pinboard-auth-lambda.zip",
@@ -3532,6 +3541,9 @@ $util.toJson($ctx.result)",
         "pinboardbootstrappinglambdaServiceRoleE9E1278C",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-bootstrapping-lambda-api/pinboard-bootstrapping-lambda-api.zip",
@@ -4292,6 +4304,9 @@ $util.toJson($ctx.result)",
         "pinboarddatabasebridgelambdaServiceRole07A568AB",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-database-bridge-lambda/pinboard-database-bridge-lambda.zip",
@@ -4490,6 +4505,9 @@ $util.toJson($ctx.result)",
         "pinboardgridbridgelambdaServiceRole33502BD3",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-grid-bridge-lambda/pinboard-grid-bridge-lambda.zip",
@@ -4632,6 +4650,9 @@ $util.toJson($ctx.result)",
         "pinboardnotificationslambdaServiceRole2F6EBFE9",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-notifications-lambda/pinboard-notifications-lambda.zip",
@@ -4837,6 +4858,9 @@ $util.toJson($ctx.result)",
         "pinboardusersrefresherlambdaServiceRoleBF872882",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-users-refresher-lambda/pinboard-users-refresher-lambda.zip",
@@ -5158,6 +5182,9 @@ $util.toJson($ctx.result)",
         "pinboardworkflowbridgelambdarole04BA8EEA",
       ],
       "Properties": Object {
+        "Architectures": Array [
+          "arm64",
+        ],
         "Code": Object {
           "S3Bucket": "workflow-dist",
           "S3Key": "workflow/TEST/pinboard-workflow-bridge-lambda/pinboard-workflow-bridge-lambda.zip",

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -190,6 +190,7 @@ export class PinBoardStack extends GuStack {
       WORKFLOW_BRIDGE_LAMBDA_BASENAME,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 128,
         timeout: Duration.seconds(5),
         handler: "index.handler",
@@ -236,6 +237,7 @@ export class PinBoardStack extends GuStack {
       gridBridgeLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 128,
         timeout: Duration.seconds(5),
         handler: "index.handler",
@@ -283,6 +285,7 @@ export class PinBoardStack extends GuStack {
       DATABASE_BRIDGE_LAMBDA_BASENAME,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 128,
         timeout: Duration.seconds(30),
         handler: "index.handler",
@@ -375,6 +378,7 @@ export class PinBoardStack extends GuStack {
       {
         vpc: accountVpc,
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 128,
         timeout: Duration.seconds(30),
         handler: "index.handler",
@@ -400,6 +404,7 @@ export class PinBoardStack extends GuStack {
       pinboardAuthLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 128,
         timeout: Duration.seconds(11),
         handler: "index.handler",
@@ -512,6 +517,7 @@ export class PinBoardStack extends GuStack {
       usersRefresherLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 512,
         timeout: Duration.minutes(15),
         handler: "index.handler",
@@ -565,6 +571,7 @@ export class PinBoardStack extends GuStack {
       securityGroups: [databaseSecurityGroup],
       functionName: `pinboard-archiver-lambda-${this.stage}`,
       runtime: LAMBDA_NODE_VERSION,
+      architecture: lambda.Architecture.ARM_64,
       handler: "index.handler",
       environment: {
         [ENVIRONMENT_VARIABLE_KEYS.databaseHostname]: databaseHostname,
@@ -603,6 +610,7 @@ export class PinBoardStack extends GuStack {
       securityGroups: [databaseSecurityGroup],
       functionName: getEmailLambdaFunctionName(this.stage as Stage),
       runtime: LAMBDA_NODE_VERSION,
+      architecture: lambda.Architecture.ARM_64,
       handler: "index.handler",
       environment: {
         [ENVIRONMENT_VARIABLE_KEYS.databaseHostname]: databaseHostname,
@@ -643,6 +651,7 @@ export class PinBoardStack extends GuStack {
       bootstrappingLambdaBasename,
       {
         runtime: LAMBDA_NODE_VERSION,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 256,
         timeout: Duration.seconds(5),
         handler: "index.handler",


### PR DESCRIPTION
Following on from https://github.com/guardian/pinboard/pull/318, this PR changes all the lambdas to use ARM (graviton) as its typically cheaper and in most cases more performant (I've read vaguely that it counteracts the increase in cold start etc. introduced by Node20 upgrade too).