### PR TITLE
add feature flag mechanism

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -2475,6 +2475,7 @@ type Mutation {
   addManuallyOpenedPinboardIds(pinboardId: String!, maybeEmailOverride: String): MyUser
   removeManuallyOpenedPinboardIds(pinboardIdToClose: String!): MyUser
   visitTourStep(tourStepId: String!): MyUser
+  changeFeatureFlag(flagId: String!, newValue: Boolean!): MyUser
 }
 
 type Subscription {
@@ -2539,6 +2540,7 @@ type MyUser {
   hasWebPushSubscription: Boolean
   manuallyOpenedPinboardIds: [String!]
   hasEverUsedTour: Boolean!
+  featureFlags: AWSJSON
 }
 
 type Group {
@@ -2669,7 +2671,28 @@ type PinboardIdWithItemCounts {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+$util.toJson($ctx.result)",
+        "TypeName": "Mutation",
+      },
+      "Type": "AWS::AppSync::Resolver",
+    },
+    "pinboardappsyncapidatabasebridgelambdadsMutationchangeFeatureFlagResolver77AF20F3": Object {
+      "DependsOn": Array [
+        "pinboardappsyncapidatabasebridgelambdads970CB9A7",
+        "pinboardappsyncapiSchema868D9F5B",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Fn::GetAtt": Array [
+            "pinboardappsyncapi9D519400",
+            "ApiId",
+          ],
+        },
+        "DataSourceName": "database_bridge_lambda_ds",
+        "FieldName": "changeFeatureFlag",
+        "Kind": "UNIT",
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2690,7 +2713,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "claimItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2711,7 +2734,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2732,7 +2755,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "deleteItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2753,7 +2776,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "editItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2774,7 +2797,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2795,7 +2818,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2816,7 +2839,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2837,7 +2860,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "visitTourStep",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2858,7 +2881,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getGroupPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2879,7 +2902,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getItemCounts",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2900,7 +2923,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2921,7 +2944,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2942,7 +2965,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2963,7 +2986,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2984,7 +3007,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3113,7 +3136,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "asGridPayload",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3134,7 +3157,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3263,7 +3286,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3284,7 +3307,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3305,7 +3328,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : aa02bae16942e48366fa36a1cd643d16
+        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -2491,9 +2491,13 @@ type Subscription {
     pinboardId: String!
   ): LastItemSeenByUser @aws_subscribe(mutations: [\\"seenItem\\"])
 
-  onManuallyOpenedPinboardIdsChanged(
+  onMyUserChanges(
     email: String! # unfortunately this can't be done via 'identity' in the resolver
-  ): MyUser @aws_subscribe(mutations: [\\"addManuallyOpenedPinboardIds\\", \\"removeManuallyOpenedPinboardIds\\"])
+  ): MyUser @aws_subscribe(mutations: [
+    \\"addManuallyOpenedPinboardIds\\",
+    \\"removeManuallyOpenedPinboardIds\\",
+    \\"changeFeatureFlag\\"
+  ])
 }
 
 type MentionHandle {
@@ -2671,7 +2675,7 @@ type PinboardIdWithItemCounts {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2692,7 +2696,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "changeFeatureFlag",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2713,7 +2717,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "claimItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2734,7 +2738,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2755,7 +2759,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "deleteItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2776,7 +2780,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "editItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2797,7 +2801,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2818,7 +2822,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2839,7 +2843,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2860,7 +2864,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "visitTourStep",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2881,7 +2885,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getGroupPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2902,7 +2906,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getItemCounts",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2923,7 +2927,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2944,7 +2948,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2965,7 +2969,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2986,7 +2990,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3007,7 +3011,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3136,7 +3140,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "asGridPayload",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3157,7 +3161,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3286,7 +3290,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3307,7 +3311,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3328,7 +3332,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : 7988db64c71d520310206ab1f55f3ca3
+        "ResponseMappingTemplate": "## schema checksum : 117bac3c96ba985bef3ad1486ee0eb07
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -180,9 +180,9 @@ export const gqlRemoveManuallyOpenedPinboardIds = gql`
     }
 `;
 
-export const gqlOnManuallyOpenedPinboardIdsChanged = (userEmail: string) => gql`
-    subscription OnManuallyOpenedPinboardIdsChanged {
-        onManuallyOpenedPinboardIdsChanged(email: "${userEmail}") {
+export const gqlOnMyUserChanges = (userEmail: string) => gql`
+    subscription onMyUserChanges {
+        onMyUserChanges(email: "${userEmail}") {
             ${myUserReturnFields}
         }
     }
@@ -271,6 +271,14 @@ export const gqlAsGridPayload = gql`
 export const gqlVisitTourStep = gql`
     mutation visitTourStep($tourStepId: String!) {
         visitTourStep(tourStepId: $tourStepId) {
+            ${myUserReturnFields}
+        }
+    }
+`;
+
+export const gqlChangeFeatureFlag = gql`
+    mutation changeFeatureFlag($flagId: String!, $newValue: Boolean!) {
+        changeFeatureFlag(flagId: $flagId, newValue: $newValue) {
             ${myUserReturnFields}
         }
     }

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -119,6 +119,7 @@ const myUserReturnFields = `${userReturnFields}
   hasWebPushSubscription
   manuallyOpenedPinboardIds
   hasEverUsedTour
+  featureFlags
 `;
 
 export const gqlSearchMentionableUsers = (prefix: string) => gql`

--- a/client/src/featureFlags.ts
+++ b/client/src/featureFlags.ts
@@ -1,0 +1,35 @@
+import { readAndThenSilentlyDropQueryParamFromURL } from "./util";
+import { ApolloClient } from "@apollo/client";
+import { gqlChangeFeatureFlag } from "../gql";
+
+export const ALLOWED_FEATURE_FLAGS = ["test"] as const;
+export type AllowedFeatureFlags = (typeof ALLOWED_FEATURE_FLAGS)[number];
+
+export type FeatureFlags = Partial<Record<AllowedFeatureFlags, boolean>>;
+
+export const extractFeatureFlags = (
+  featureFlagsStr: string | null | undefined
+): FeatureFlags =>
+  featureFlagsStr ? (JSON.parse(featureFlagsStr) as FeatureFlags) : {};
+
+export const consumeFeatureFlagQueryParamsAndUpdateAccordingly = (
+  apolloClient: ApolloClient<unknown>
+) =>
+  ALLOWED_FEATURE_FLAGS.forEach((flagId) => {
+    const flagStringValue = readAndThenSilentlyDropQueryParamFromURL(
+      `pinboardFeatureFlag_${flagId}`
+    );
+    if (flagStringValue !== null) {
+      apolloClient
+        .mutate({
+          mutation: gqlChangeFeatureFlag,
+          variables: {
+            flagId,
+            newValue: flagStringValue === "true",
+          },
+        })
+        .catch(console.error);
+      // we rely on the subscription 'updateUserWithChanges' to deliver the
+      // MyUser changes back to all connected clients (like we do for manuallyAddedPinboardIds)
+    }
+  });

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -33,6 +33,7 @@ import {
 import { UserLookup } from "./types/UserLookup";
 import { demoPinboardData } from "./tour/tourConstants";
 import { readAndThenSilentlyDropQueryParamFromURL } from "./util";
+import { FeatureFlags } from "./featureFlags";
 
 const LOCAL_STORAGE_KEY_EXPLICIT_POSITION = "pinboard-explicit-position";
 
@@ -69,6 +70,8 @@ interface GlobalStateContextShape {
 
   hasEverUsedTour: boolean | undefined;
   visitTourStep: (tourStepId: string) => void;
+
+  featureFlags: FeatureFlags;
 
   showNotification: (item: Item) => void;
   hasWebPushSubscription: boolean | null | undefined;
@@ -124,12 +127,13 @@ interface GlobalStateProviderProps {
   addEmailsToLookup: (emails: string[]) => void;
   hasWebPushSubscription: boolean | null | undefined;
   manuallyOpenedPinboardIds: string[];
-  setManuallyOpenedPinboardIds: (newMyUser: MyUser) => void;
+  updateUserWithChanges: (newMyUser: MyUser) => void;
   showNotification: (item: Item) => void;
   clearDesktopNotificationsForPinboardId: (pinboardId: string) => void;
   presetUnreadNotificationCount: number | undefined;
   hasEverUsedTour: boolean | undefined;
   visitTourStep: (tourStepId: string) => void;
+  featureFlags: FeatureFlags;
 }
 
 export const GlobalStateProvider = ({
@@ -145,11 +149,12 @@ export const GlobalStateProvider = ({
   addEmailsToLookup,
   hasWebPushSubscription,
   manuallyOpenedPinboardIds,
-  setManuallyOpenedPinboardIds,
+  updateUserWithChanges,
   showNotification,
   clearDesktopNotificationsForPinboardId,
   hasEverUsedTour,
   visitTourStep,
+  featureFlags,
   children,
 }: PropsWithChildren<GlobalStateProviderProps>) => {
   const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
@@ -353,9 +358,7 @@ export const GlobalStateProvider = ({
         addManuallyOpenedPinboardId(isDemo)(pinboardData.id).then(
           (result) =>
             result.data
-              ? setManuallyOpenedPinboardIds(
-                  result.data.addManuallyOpenedPinboardIds
-                )
+              ? updateUserWithChanges(result.data.addManuallyOpenedPinboardIds)
               : console.error(
                   "addManuallyOpenedPinboardIds did not return any data"
                 ) // TODO probably report to Sentry
@@ -421,9 +424,7 @@ export const GlobalStateProvider = ({
       }).then(
         (result) =>
           result.data
-            ? setManuallyOpenedPinboardIds(
-                result.data.removeManuallyOpenedPinboardIds
-              )
+            ? updateUserWithChanges(result.data.removeManuallyOpenedPinboardIds)
             : console.error(
                 "removeManuallyOpenedPinboardIds did not return any data"
               ) // TODO probably report to Sentry
@@ -561,6 +562,8 @@ export const GlobalStateProvider = ({
 
     hasEverUsedTour,
     visitTourStep,
+
+    featureFlags,
 
     showNotification,
     hasWebPushSubscription,

--- a/database-bridge-lambda/src/index.ts
+++ b/database-bridge-lambda/src/index.ts
@@ -15,6 +15,7 @@ import { Sql } from "../../shared/database/types";
 import { listLastItemSeenByUsers, seenItem } from "./sql/LastItemSeenByUser";
 import {
   addManuallyOpenedPinboardIds,
+  changeFeatureFlag,
   getMyUser,
   getUsers,
   removeManuallyOpenedPinboardIds,
@@ -66,6 +67,8 @@ const run = (
       return getItemCounts(sql, args, userEmail);
     case "visitTourStep":
       return visitTourStep(sql, args, userEmail);
+    case "changeFeatureFlag":
+      return changeFeatureFlag(sql, args, userEmail);
   }
 
   throw Error(

--- a/shared/database/local/runDatabaseSetup.ts
+++ b/shared/database/local/runDatabaseSetup.ts
@@ -85,6 +85,8 @@ const runSetupTriggerSqlFile = (
           getEmailLambdaFunctionName(stage),
           EMAIL_DATABASE_TRIGGER_NAME
         ),
+    "add featureFlags column to User table": () =>
+      runSetupSqlFile(sql, "020-AddFeatureFlagsColumnToUserTable.sql"),
   };
 
   const allSteps = async () => {

--- a/shared/database/local/setup/020-AddFeatureFlagsColumnToUserTable.sql
+++ b/shared/database/local/setup/020-AddFeatureFlagsColumnToUserTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "featureFlags" JSONB;

--- a/shared/graphql/operations.ts
+++ b/shared/graphql/operations.ts
@@ -38,6 +38,7 @@ export const MUTATIONS = {
     "addManuallyOpenedPinboardIds",
     "removeManuallyOpenedPinboardIds",
     "visitTourStep",
+    "changeFeatureFlag",
   ] as const,
 } as const;
 

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -32,6 +32,7 @@ type Mutation {
   addManuallyOpenedPinboardIds(pinboardId: String!, maybeEmailOverride: String): MyUser
   removeManuallyOpenedPinboardIds(pinboardIdToClose: String!): MyUser
   visitTourStep(tourStepId: String!): MyUser
+  changeFeatureFlag(flagId: String!, newValue: Boolean!): MyUser
 }
 
 type Subscription {
@@ -96,6 +97,7 @@ type MyUser {
   hasWebPushSubscription: Boolean
   manuallyOpenedPinboardIds: [String!]
   hasEverUsedTour: Boolean!
+  featureFlags: AWSJSON
 }
 
 type Group {

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -48,9 +48,13 @@ type Subscription {
     pinboardId: String!
   ): LastItemSeenByUser @aws_subscribe(mutations: ["seenItem"])
 
-  onManuallyOpenedPinboardIdsChanged(
+  onMyUserChanges(
     email: String! # unfortunately this can't be done via 'identity' in the resolver
-  ): MyUser @aws_subscribe(mutations: ["addManuallyOpenedPinboardIds", "removeManuallyOpenedPinboardIds"])
+  ): MyUser @aws_subscribe(mutations: [
+    "addManuallyOpenedPinboardIds",
+    "removeManuallyOpenedPinboardIds",
+    "changeFeatureFlag"
+  ])
 }
 
 type MentionHandle {


### PR DESCRIPTION
As a pre-requisite to #312 we needed a way for users to gradually enrol into the new functionality as they receive 'training', which needed to persist across machines and work consistently in different tools, so storing a new column in the DB seemed sensible ...

- new JSONB column, called `featureFlags` on the `User` table
- becomes a field of the `MyUser` type (just a JSON string, parsed in the client)
- parsed `feautureFlags` shared around the app via the GlobalStateContext
- new GraphQL mutation `changeFeatureFlag` which writes key/values to the featureFlags JSONB column
- consumes changes to feature flags via query params with prefix `pinboardFeatureFlag_`, dropping them from URL once the new mutation `changeFeatureFlag` has been called with the new value (`true` or `false`) -- this allows trainers to provide a URL with feature flag query param to users and then it will remain on for the user indefinitely following their training
- renames/broadens the GraphQL subscription `onManuallyOpenedPinboardIdsChanged` to become `onMyUserChanges` and now fires based on the new mutation too, which allows all connected clients to hear about changes to featureFlags and react accordingly