### PR TITLE
log error if the email-lambda is invoked directly/instantly for a group mention but then the logic concludes that there are "No items to email about"

### DIFF
--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -71,6 +71,15 @@ export const handler = async (maybeSendImmediatelyDetail?: {
        * will need their isEmailEvaluated flag set to true at the bottom
        * of this file, so they aren't continually picked up
        */
+
+      if (itemIdWithGroupMention) {
+        console.error(
+          "Item with ID",
+          itemIdWithGroupMention,
+          "has no group mentions to email about. This is unexpected.",
+          { itemsToEmailAbout }
+        );
+      }
     }
 
     if (itemsToEmailAbout.length === 0) {


### PR DESCRIPTION
...as we observed with a CP mention recently but no email was sent

Pondering whether there is a race condition, since the lambda is invoked async from an `AFTER INSERT` DB trigger and then DB is immediately queried for that ID