### PR TITLE
cap the display and mounting of more than 50 pinboards

### DIFF
--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -9,7 +9,10 @@ import {
   top,
 } from "./styling";
 import { Pinboard } from "./pinboard";
-import { SelectPinboard } from "./selectPinboard";
+import {
+  MAX_OPEN_PINBOARDS_TO_DISPLAY,
+  SelectPinboard,
+} from "./selectPinboard";
 import { neutral, space } from "@guardian/source-foundations";
 import { Navigation } from "./navigation";
 import { useGlobalStateContext } from "./globalState";
@@ -297,22 +300,26 @@ export const Panel = ({
       {
         // The active pinboards are always mounted, so that we receive new item notifications
         // Note that the pinboard hides itself based on 'isSelected' prop
-        activePinboardIds.map((pinboardId) => (
-          <Pinboard
-            key={pinboardId}
-            pinboardId={pinboardId}
-            composerId={useMemo(
-              () =>
-                activePinboards.find((_) => _.id === pinboardId)?.composerId ||
-                null,
-              [activePinboards, pinboardId]
-            )}
-            isExpanded={pinboardId === selectedPinboardId && isExpanded}
-            isSelected={pinboardId === selectedPinboardId}
-            panelElement={panelRef.current}
-            setMaybeInlineSelectedPinboardId={setMaybeInlineSelectedPinboardId}
-          />
-        ))
+        activePinboardIds
+          .slice(0, MAX_OPEN_PINBOARDS_TO_DISPLAY)
+          .map((pinboardId) => (
+            <Pinboard
+              key={pinboardId}
+              pinboardId={pinboardId}
+              composerId={useMemo(
+                () =>
+                  activePinboards.find((_) => _.id === pinboardId)
+                    ?.composerId || null,
+                [activePinboards, pinboardId]
+              )}
+              isExpanded={pinboardId === selectedPinboardId && isExpanded}
+              isSelected={pinboardId === selectedPinboardId}
+              panelElement={panelRef.current}
+              setMaybeInlineSelectedPinboardId={
+                setMaybeInlineSelectedPinboardId
+              }
+            />
+          ))
       }
 
       {maybePeekingAtPinboard && (

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -50,6 +50,8 @@ const SectionHeading: React.FC = ({ children }) => (
   <div css={{ ...textMarginCss, color: palette.neutral["46"] }}>{children}</div>
 );
 
+export const MAX_OPEN_PINBOARDS_TO_DISPLAY = 1;
+
 interface SelectPinboardProps {
   pinboardsWithClaimCounts: PinboardDataWithClaimCounts[];
   peekAtPinboard: (pinboard: PinboardData) => void;
@@ -118,9 +120,21 @@ export const SelectPinboard = ({
     };
   }, []);
 
-  const activePinboardsWithoutPreselected = isPinboardData(preselectedPinboard)
+  const _allActivePinboardsWithoutPreselected = isPinboardData(
+    preselectedPinboard
+  )
     ? activePinboards.filter((_) => _.id !== preselectedPinboard.id)
     : activePinboards;
+
+  const activePinboardsWithoutPreselected =
+    _allActivePinboardsWithoutPreselected.slice(
+      0,
+      MAX_OPEN_PINBOARDS_TO_DISPLAY
+    );
+
+  const numberOfPinboardsOverDisplayLimit =
+    _allActivePinboardsWithoutPreselected.length -
+    activePinboardsWithoutPreselected.length;
 
   const [searchPinboards, { data, loading, stopPolling, startPolling }] =
     useLazyQuery<{
@@ -453,6 +467,22 @@ export const SelectPinboard = ({
                 : activePinboardsWithoutPreselected
               ).map(OpenPinboardButton)}
               {isLoadingActivePinboardList && <SvgSpinner size="xsmall" />}
+              {numberOfPinboardsOverDisplayLimit > 0 && (
+                <div
+                  css={css`
+                    padding: ${space[1]};
+                    font-style: italic;
+                  `}
+                >
+                  <strong>
+                    PLUS {numberOfPinboardsOverDisplayLimit} more, which cannot
+                    be displayed.
+                  </strong>{" "}
+                  Please close some unused pinboards and raise with production
+                  staff to ensure workflow items have the correct status so they
+                  get cleaned up accordingly.
+                </div>
+              )}
               <div css={{ height: space[2] }} />
             </React.Fragment>
           )}

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -50,7 +50,7 @@ const SectionHeading: React.FC = ({ children }) => (
   <div css={{ ...textMarginCss, color: palette.neutral["46"] }}>{children}</div>
 );
 
-export const MAX_OPEN_PINBOARDS_TO_DISPLAY = 1;
+export const MAX_OPEN_PINBOARDS_TO_DISPLAY = 50;
 
 interface SelectPinboardProps {
   pinboardsWithClaimCounts: PinboardDataWithClaimCounts[];
@@ -470,7 +470,8 @@ export const SelectPinboard = ({
               {numberOfPinboardsOverDisplayLimit > 0 && (
                 <div
                   css={css`
-                    padding: ${space[1]};
+                    padding: ${space[2]}px;
+                    font-weight: normal;
                     font-style: italic;
                   `}
                 >


### PR DESCRIPTION
since Apollo doesn't support more than 100 subscriptions (as discovered by real user 🫨 ) and more than 50 open pinboards suggests people aren't transitioning workflow items to the right statuses

in a follow-up PR I'd like to start logging (probably via Sentry) when this happens, otherwise we'll never know.

_With the limit artificially set to one for the purposes of screenshot..._
<img width="314" alt="image" src="https://github.com/user-attachments/assets/a85fc69d-6955-46c6-a863-5061b44306f0">
