### PR TITLE
consolidate subscriptions per active pinboard into a few subscriptions at the top level AND eliminate worst/expensive forms of polling

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -2568,7 +2568,7 @@ type Subscription {
   ): Claimed @aws_subscribe(mutations: [\\"claimItem\\"])
 
   onSeenItem(
-    pinboardId: String!
+    pinboardId: String
   ): LastItemSeenByUser @aws_subscribe(mutations: [\\"seenItem\\"])
 
   onMyUserChanges(
@@ -2759,7 +2759,7 @@ type PinboardIdWithItemCounts {
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2780,7 +2780,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "changeFeatureFlag",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2801,7 +2801,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "claimItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2822,7 +2822,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2843,7 +2843,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "deleteItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2864,7 +2864,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "editItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2885,7 +2885,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2906,7 +2906,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2927,7 +2927,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2948,7 +2948,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "visitTourStep",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Mutation",
       },
@@ -2969,7 +2969,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getGroupPinboardIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2990,7 +2990,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getItemCounts",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3011,7 +3011,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3032,7 +3032,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "getUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3053,7 +3053,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3074,7 +3074,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3095,7 +3095,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "database_bridge_lambda_ds",
         "FieldName": "searchMentionableUsers",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3224,7 +3224,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "asGridPayload",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3245,7 +3245,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "grid_bridge_lambda_ds",
         "FieldName": "getGridSearchSummary",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3374,7 +3374,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3395,7 +3395,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3416,7 +3416,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByPaths",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -3437,7 +3437,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : da5ab4d1435d8fb629c068ee4933d29c
+        "ResponseMappingTemplate": "## schema checksum : af8a4c1d6bcf5d68837b1d756334f705
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -111,9 +111,9 @@ export const gqlDeleteItem = gql`
         }
     }
 `;
-export const gqlOnMutateItem = (pinboardId: string) => gql`
+export const gqlOnMutateItem = gql`
     subscription OnMutateItem {
-        onMutateItem(pinboardId: "${pinboardId}") { ${itemReturnFields} }
+        onMutateItem { ${itemReturnFields} }
     }
 `;
 
@@ -212,9 +212,9 @@ export const gqlGetLastItemSeenByUsers = (pinboardId: string) => gql`
     }
 `;
 
-export const gqlOnSeenItem = (pinboardId: string) => gql`
+export const gqlOnSeenItem = gql`
     subscription OnSeenItem {
-        onSeenItem(pinboardId: "${pinboardId}") { ${lastItemSeenByUserReturnFields} }
+        onSeenItem { ${lastItemSeenByUserReturnFields} }
     }
 `;
 
@@ -245,9 +245,9 @@ export const gqlClaimItem = gql`
     }
 `;
 
-export const gqlOnClaimItem = (pinboardId: string) => gql`
+export const gqlOnClaimItem = gql`
     subscription OnClaimItem {
-        onClaimItem(pinboardId: "${pinboardId}") { ${claimedReturnFields} }
+        onClaimItem { ${claimedReturnFields} }
     }
 `;
 

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -432,6 +432,7 @@ export const PinBoardApp = ({
           hasEverUsedTour={me?.hasEverUsedTour}
           visitTourStep={visitTourStep}
           featureFlags={featureFlags}
+          maybeInlineSelectedPinboardId={maybeInlineSelectedPinboardId}
         >
           <TourStateProvider>
             <Global styles={agateFontFaceIfApplicable} />

--- a/client/src/fronts/frontsIntegration.tsx
+++ b/client/src/fronts/frontsIntegration.tsx
@@ -40,7 +40,8 @@ export const FrontsIntegration = ({
     [frontsPinboardElements]
   );
 
-  const { setError } = useGlobalStateContext();
+  const { setError, totalItemsReceivedViaSubscription } =
+    useGlobalStateContext();
 
   const apolloClient = useApolloClient();
 
@@ -84,8 +85,11 @@ export const FrontsIntegration = ({
     variables: {
       pinboardIds,
     },
-    pollInterval: 10_000, //TODO consider subscribing to all messages and fetching counts based on that, might be more efficient
   });
+
+  useEffect(() => {
+    itemCountsQuery.refetch();
+  }, [totalItemsReceivedViaSubscription]);
 
   useEffect(() => {
     itemCountsQuery.data?.getItemCounts &&

--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -6,7 +6,7 @@ import { PayloadWithThumbnail } from "../types/PayloadAndType";
 import root from "react-shadow/emotion";
 import { useApolloClient } from "@apollo/client";
 import { useGlobalStateContext } from "../globalState";
-import { CreateItemInput, Item } from "shared/graphql/graphql";
+import { CreateItemInput } from "shared/graphql/graphql";
 import { gqlCreateItem } from "../../gql";
 import { isPinboardData } from "shared/graphql/extraTypes";
 import { agateSans } from "../../fontNormaliser";

--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -6,7 +6,7 @@ import { PayloadWithThumbnail } from "../types/PayloadAndType";
 import root from "react-shadow/emotion";
 import { useApolloClient } from "@apollo/client";
 import { useGlobalStateContext } from "../globalState";
-import { CreateItemInput } from "shared/graphql/graphql";
+import { CreateItemInput, Item } from "shared/graphql/graphql";
 import { gqlCreateItem } from "../../gql";
 import { isPinboardData } from "shared/graphql/extraTypes";
 import { agateSans } from "../../fontNormaliser";

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -566,7 +566,8 @@ export const GlobalStateProvider = ({
     }
     setSelectedPinboardId(null);
     setError(pinboardIdToClose, undefined);
-    //TODO probably need to check if pinboard is also in group pinboards, so we don't lose an unread on there
+
+    // note that panel.tsx detects this and reinstates any hasUnread from the group pinboards
     setUnreadFlag(pinboardIdToClose)(undefined);
   };
 

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useMemo, useState } from "react";
 import { InlineModePinboardTogglePortal } from "./inlineModePinboardToggle";
 import { useLazyQuery } from "@apollo/client";
 import { gqlGetItemCounts } from "../../gql";
-import { PinboardIdWithItemCounts } from "../../../shared/graphql/graphql";
+import { PinboardIdWithItemCounts } from "shared/graphql/graphql";
 import { InlineModePanel } from "./inlineModePanel";
 import ReactDOM from "react-dom";
 import { InlineModeWorkflowColumnHeading } from "./inlineModeWorkflowColumnHeading";
+import { useGlobalStateContext } from "../globalState";
 
 export const WORKFLOW_PINBOARD_ELEMENTS_QUERY_SELECTOR =
   ".content-list-item__field--pinboard";
@@ -37,6 +38,8 @@ export const InlineMode = ({
   maybeInlineSelectedPinboardId,
   setMaybeInlineSelectedPinboardId,
 }: InlineModeProps) => {
+  const { totalItemsReceivedViaSubscription } = useGlobalStateContext();
+
   const pinboardArea = useMemo(
     () => document.getElementById("pinboard-area"),
     []
@@ -55,11 +58,9 @@ export const InlineMode = ({
     Record<string, PinboardIdWithItemCounts>
   >({});
 
-  const [fetchItemCounts, { stopPolling, startPolling }] =
-    useLazyQuery(gqlGetItemCounts);
+  const [fetchItemCounts] = useLazyQuery(gqlGetItemCounts);
 
   useEffect(() => {
-    stopPolling();
     const pinboardIds = Object.keys(workflowTitleElementLookup);
     if (pinboardIds.length > 0) {
       fetchItemCounts({
@@ -80,9 +81,8 @@ export const InlineMode = ({
             )
           ),
       });
-      startPolling(15000);
     }
-  }, [workflowTitleElementLookup]);
+  }, [workflowTitleElementLookup, totalItemsReceivedViaSubscription]);
 
   const maybeSelectedNode =
     maybeInlineSelectedPinboardId &&

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -67,6 +67,7 @@ export const Panel = ({
     setActiveTab,
     boundedPositionTranslation,
     setUnreadFlag,
+    totalItemsReceivedViaSubscription,
   } = useGlobalStateContext();
 
   const tourProgress = useTourProgress();
@@ -94,9 +95,11 @@ export const Panel = ({
   const isTopHalf =
     Math.abs(boundedPositionTranslation.y) > window.innerHeight / 2;
 
-  const groupPinboardIdsQuery = useQuery(gqlGetGroupPinboardIds, {
-    pollInterval: 15000, // always poll this one, to ensure we get unread flags even when pinboard is not expanded
-  });
+  const groupPinboardIdsQuery = useQuery(gqlGetGroupPinboardIds);
+
+  useEffect(() => {
+    groupPinboardIdsQuery.refetch();
+  }, [totalItemsReceivedViaSubscription]);
 
   const groupPinboardIdsWithClaimCounts: PinboardIdWithClaimCounts[] = useMemo(
     () =>

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -66,6 +66,7 @@ export const Panel = ({
     activeTab,
     setActiveTab,
     boundedPositionTranslation,
+    unreadFlags,
     setUnreadFlag,
     totalItemsReceivedViaSubscription,
   } = useGlobalStateContext();
@@ -108,6 +109,15 @@ export const Panel = ({
       ),
     [groupPinboardIdsQuery.data]
   );
+
+  useEffect(() => {
+    // ensure that if ever the pinboard is closed manually, the hasUnread from the group pinboards becomes the value
+    groupPinboardIdsWithClaimCounts.forEach(
+      ({ pinboardId, hasUnread }) =>
+        unreadFlags[pinboardId] === undefined &&
+        setUnreadFlag(pinboardId)(hasUnread)
+    );
+  }, [unreadFlags]);
 
   useEffect(() => {
     groupPinboardIdsWithClaimCounts.forEach(({ pinboardId, hasUnread }) =>

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -266,7 +266,7 @@ export const Panel = ({
       <Global styles={highlightItemsKeyFramesCSS} />
 
       {
-        // The active pinboards are always mounted, so that we receive new item notifications
+        // The active pinboards are always mounted
         // Note that the pinboard hides itself based on 'isSelected' prop
         activePinboardIds.map((pinboardId) => (
           <Pinboard

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -46,7 +46,7 @@ type Subscription {
   ): Claimed @aws_subscribe(mutations: ["claimItem"])
 
   onSeenItem(
-    pinboardId: String!
+    pinboardId: String
   ): LastItemSeenByUser @aws_subscribe(mutations: ["seenItem"])
 
   onMyUserChanges(


### PR DESCRIPTION
## Background 

In response to a user being effectively blocked from using pinboard due to reaching 100 AppSync subscriptions (a limit we were previously unaware of), we raised #323 to cap the number of 'my pinboards' _mounted_ to 50 as each one had a subscription to listen to messages for that pinboard, but this did not solve the problem as it turns out each pinboard actually had 3 subscriptions (one for items, one for claims and one for last item seen) and the user had 34 'my pinboards' 🤦  (the change was therefore reverted in #324 as it was ineffective).

Whilst a user having so many 'my pinboards' is really a symptom of poor housekeeping in workflow... it did make me re-evaluate the idea of 3 subscriptions per mounted pinboard... which I concluded was pretty wasteful.

## Consolidating Subscriptions
So now instead of 3 subscriptions PER 'my pinboard' we now have 3 _shared_ subscriptions up in the global state, listening to ALL new items, ALL claims and ALL last item seen, then storing to state only those which are relevant to any of the 'my pinboards' and then individual instances of `Pinboard` pull from the global state and filter for the ones with matching `pinboardId` - this is much more efficient.

## Eliminating some polling
With the shared subscriptions in place, listening for everything, we can now keep a count (running total) of all items created/changed/claimed in ANY pinboard, and use that to trigger the `getGroupPinboardIds` and `getItemCounts` queries previously performed on a polling frequency (see #304 for when polling frequency was reduced to save money). 

Since the polling is 15s currently (see #304) is now it's being replaced with it being triggered by things actually being sent/claimed **we should expect things to be more realtime** (by up to 15s improvement effectively).

### Potential/Probable Cost Savings
We know that AppSync queries make up the vast majority of the cost of running pinboard...

<img width="933" alt="image" src="https://github.com/user-attachments/assets/9d508235-4e03-495f-b3d0-e10c41b17b35">

... we know we **average around 1.7millions AppSync requests per day** currently (down from 3.7mill per day prior to #304), and of those requests `getGroupPinboardIds` and `getItemCounts` make up the vast majority...

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/953e4656-0217-4f5d-8604-f1317052f011">

... but we also know that there are vastly fewer messages sent/claimed per day (around 50 per day) than the total number of AppSync requests...

<img width="1374" alt="image" src="https://github.com/user-attachments/assets/dc451d8e-20b7-48ad-98fa-aed636788d37">

... so we should see far fewer requests in total once this is release and therefore I am relatively confident that replacing these two expensive forms of polling we should see some significant cost savings too 💸 🎉 .