### PR TITLE
alarm on `email-lambda` race condition and hopefully eliminate with a 5s delay before querying

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -27,6 +27,7 @@ Object {
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
       "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "59.5.6",
   },
@@ -1560,6 +1561,84 @@ Object {
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "EmailLambdaRaceConditionAlarmB1E6FE09": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":Cloudwatch-Alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "This occurs when the email-lambda has been invoked directly from RDS, being passed the ID of an item with group mentions, yet when querying the database for the item, it has no group mentions to email about. This is unexpected and indicates a race condition.",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "EmailLambdaRaceCondition",
+        "Namespace": "Pinboard",
+        "Period": 300,
+        "Statistic": "Average",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "pinboard",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "59.5.6",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/pinboard",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "workflow",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "EmailLambdaRaceConditionMetricFilterC63DB9EC": Object {
+      "Properties": Object {
+        "FilterPattern": "has no group mentions to email about. This is unexpected.",
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "EmailLambda93E95E21",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": Array [
+          Object {
+            "MetricName": "EmailLambdaRaceCondition",
+            "MetricNamespace": "Pinboard",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
     },
     "EmailLambdaServiceRoleCBE95916": Object {
       "Properties": Object {

--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -1,6 +1,9 @@
 import { getDatabaseConnection } from "shared/database/databaseConnection";
 import { STAGE, standardAwsConfig } from "shared/awsIntegration";
-import { getWorkflowBridgeLambdaFunctionName } from "shared/constants";
+import {
+  EMAIL_LAMBDA_RACE_CONDITION_LOG_LINE_SNIPPET,
+  getWorkflowBridgeLambdaFunctionName,
+} from "shared/constants";
 import { Stage } from "shared/types/stage";
 import { WorkflowStub } from "shared/graphql/graphql";
 import { Lambda } from "@aws-sdk/client-lambda";
@@ -80,7 +83,7 @@ export const handler = async (maybeSendImmediatelyDetail?: {
         console.error(
           "Item with ID",
           itemIdWithGroupMention,
-          "has no group mentions to email about. This is unexpected.",
+          EMAIL_LAMBDA_RACE_CONDITION_LOG_LINE_SNIPPET,
           { itemsToEmailAbout }
         );
       }

--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -59,6 +59,10 @@ export const handler = async (maybeSendImmediatelyDetail?: {
   const sql = await getDatabaseConnection();
 
   try {
+    if (itemIdWithGroupMention) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+
     const itemsToEmailAbout = await getItemsToEmailAbout(
       sql,
       itemIdWithGroupMention

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -27,3 +27,6 @@ export const getEmailLambdaFunctionName = (stage: Stage) =>
 export const OPEN_PINBOARD_QUERY_PARAM = "pinboardId";
 export const PINBOARD_ITEM_ID_QUERY_PARAM = "pinboardItemId";
 export const EXPAND_PINBOARD_QUERY_PARAM = "expandPinboard";
+
+export const EMAIL_LAMBDA_RACE_CONDITION_LOG_LINE_SNIPPET =
+  "has no group mentions to email about. This is unexpected.";


### PR DESCRIPTION
In #322 we added some logging for a suspected race condition in `email-lambda`. This PR adds an alarm as we want to hear about it (it has occurred once since the extra logging was added). 

As a crude way of potentially solving the problem, this PR also adds a 5s wait within the lambda when it's invoked directly from RDS - ~if this doesn't work OR if it means the message is slower to send for users, then we should change the invocation_type to asynchronous in the DB trigger (i.e. fire and forget) and turn on alarms for failed invocations of the lambda instead~ tested and send time is not impacted by the delay (despite synchronous invocation of lambda within RDS DB trigger).