### PR TITLE
add `Stage` to the namespace of the metric filter designed to catch the `email-lambda` race condition

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -1632,6 +1632,12 @@ Object {
         },
         "MetricTransformations": Array [
           Object {
+            "Dimensions": Array [
+              Object {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
             "MetricName": "EmailLambdaRaceCondition",
             "MetricNamespace": "Pinboard",
             "MetricValue": "1",

--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -1587,7 +1587,7 @@ Object {
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "EvaluationPeriods": 1,
         "MetricName": "EmailLambdaRaceCondition",
-        "Namespace": "Pinboard",
+        "Namespace": "Pinboard/TEST",
         "Period": 300,
         "Statistic": "Average",
         "Tags": Array [
@@ -1632,14 +1632,8 @@ Object {
         },
         "MetricTransformations": Array [
           Object {
-            "Dimensions": Array [
-              Object {
-                "Key": "Stage",
-                "Value": "TEST",
-              },
-            ],
             "MetricName": "EmailLambdaRaceCondition",
-            "MetricNamespace": "Pinboard",
+            "MetricNamespace": "Pinboard/TEST",
             "MetricValue": "1",
           },
         ],

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -655,6 +655,9 @@ export class PinBoardStack extends GuStack {
         ),
         metricName: "EmailLambdaRaceCondition",
         metricNamespace: "Pinboard",
+        dimensions: {
+          Stage: this.stage,
+        },
         filterPattern: {
           logPatternString: EMAIL_LAMBDA_RACE_CONDITION_LOG_LINE_SNIPPET,
         },

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -654,10 +654,7 @@ export class PinBoardStack extends GuStack {
           `/aws/lambda/${emailLambda.functionName}`
         ),
         metricName: "EmailLambdaRaceCondition",
-        metricNamespace: "Pinboard",
-        dimensions: {
-          Stage: this.stage,
-        },
+        metricNamespace: `Pinboard/${this.stage}`,
         filterPattern: {
           logPatternString: EMAIL_LAMBDA_RACE_CONDITION_LOG_LINE_SNIPPET,
         },


### PR DESCRIPTION
Tiny tweak following #326 as I noticed CODE and PROD published to the same metric, as such if the issue occurred in either CODE or PROD, then both CODE and PROD alarms would fire - which is not what we want. This PR should address that.