### PR TITLE
also trigger re-fetch of `getItemCounts` and `getGroupPinboardIds` whenever user receives any of their OWN `LastItemSeenByUser`

### DIFF
--- a/client/src/fronts/frontsIntegration.tsx
+++ b/client/src/fronts/frontsIntegration.tsx
@@ -30,8 +30,11 @@ export const FrontsIntegration = ({
     [frontsPinboardElements]
   );
 
-  const { setError, totalItemsReceivedViaSubscription } =
-    useGlobalStateContext();
+  const {
+    setError,
+    totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  } = useGlobalStateContext();
 
   const apolloClient = useApolloClient();
 
@@ -79,7 +82,10 @@ export const FrontsIntegration = ({
 
   useEffect(() => {
     itemCountsQuery.refetch();
-  }, [totalItemsReceivedViaSubscription]);
+  }, [
+    totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  ]);
 
   useEffect(() => {
     itemCountsQuery.data?.getItemCounts &&

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -68,6 +68,7 @@ interface GlobalStateContextShape {
   allSubscriptionClaimedItems: Item[]; // both the updated 'claimed' item and the new 'claim' item
   allSubscriptionOnSeenItems: LastItemSeenByUser[];
   totalItemsReceivedViaSubscription: number;
+  totalOfMyOwnOnSeenItemsReceivedViaSubscription: number;
 
   payloadToBeSent: PayloadAndType | null;
   setPayloadToBeSent: (newPayloadToBeSent: PayloadAndType | null) => void;
@@ -341,6 +342,11 @@ export const GlobalStateProvider = ({
     },
   });
 
+  const [
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+    setTotalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  ] = useState(0);
+
   const [allSubscriptionOnSeenItems, setAllSubscriptionOnSeenItems] = useState<
     LastItemSeenByUser[]
   >([]);
@@ -358,6 +364,9 @@ export const GlobalStateProvider = ({
           ...prevState,
           newLastItemSeenByUser,
         ]);
+      }
+      if (newLastItemSeenByUser.userEmail === userEmail) {
+        setTotalOfMyOwnOnSeenItemsReceivedViaSubscription((prev) => prev + 1);
       }
     },
   });
@@ -688,6 +697,7 @@ export const GlobalStateProvider = ({
     allSubscriptionClaimedItems,
     allSubscriptionOnSeenItems,
     totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
 
     payloadToBeSent,
     setPayloadToBeSent,

--- a/client/src/inline/inlineMode.tsx
+++ b/client/src/inline/inlineMode.tsx
@@ -38,7 +38,10 @@ export const InlineMode = ({
   maybeInlineSelectedPinboardId,
   setMaybeInlineSelectedPinboardId,
 }: InlineModeProps) => {
-  const { totalItemsReceivedViaSubscription } = useGlobalStateContext();
+  const {
+    totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  } = useGlobalStateContext();
 
   const pinboardArea = useMemo(
     () => document.getElementById("pinboard-area"),
@@ -82,7 +85,11 @@ export const InlineMode = ({
           ),
       });
     }
-  }, [workflowTitleElementLookup, totalItemsReceivedViaSubscription]);
+  }, [
+    workflowTitleElementLookup,
+    totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  ]);
 
   const maybeSelectedNode =
     maybeInlineSelectedPinboardId &&

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -69,6 +69,7 @@ export const Panel = ({
     unreadFlags,
     setUnreadFlag,
     totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
   } = useGlobalStateContext();
 
   const tourProgress = useTourProgress();
@@ -100,7 +101,10 @@ export const Panel = ({
 
   useEffect(() => {
     groupPinboardIdsQuery.refetch();
-  }, [totalItemsReceivedViaSubscription]);
+  }, [
+    totalItemsReceivedViaSubscription,
+    totalOfMyOwnOnSeenItemsReceivedViaSubscription,
+  ]);
 
   const groupPinboardIdsWithClaimCounts: PinboardIdWithClaimCounts[] = useMemo(
     () =>


### PR DESCRIPTION
…via `onSeenItem` subscription, to ensure things viewed in one tab/tool are reflected in the counts in other tabs/tools.

Arguably missed in #325 