### PR TITLE
Mention external panda cookie requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run `./scripts/setup.sh`, which...
 - Ensure you have the latest AWS credentials (profile: `workflow`)
 - Run `./scripts/start.sh`
 - To check it's up, hit https://pinboard.local.dev-gutools.co.uk (to see the PinBoard floaty etc. on a blank page - having gone through the auth and permission checks - if you don't see anything take a look at the console in the browser)
-- If the page doesn't seem to be working, and there is a [panda](https://github.com/guardian/pan-domain-authentication)-related error in the console, you may need to run and open another tool locally (like [Composer](https://github.com/guardian/flexible-content/pull/4077/files)) in order to generate the required auth cookies
+- If the page doesn't seem to be working, and there is a [panda](https://github.com/guardian/pan-domain-authentication)-related error in the console, you may need to run and open another tool locally (like [Composer](https://github.com/guardian/flexible-content)) in order to generate the required auth cookies
 
 NOTE: locally it uses the CODE AppSync API instance (since AppSync is a paid feature of localstack)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Run `./scripts/setup.sh`, which...
 
 - Ensure you have the latest AWS credentials (profile: `workflow`)
 - Run `./scripts/start.sh`
-- to check it's up, hit https://pinboard.local.dev-gutools.co.uk (to see the PinBoard floaty etc. on a blank page - having gone through the auth and permission checks - if you don't see anything take a look at the console in the browser)
+- To check it's up, hit https://pinboard.local.dev-gutools.co.uk (to see the PinBoard floaty etc. on a blank page - having gone through the auth and permission checks - if you don't see anything take a look at the console in the browser)
+- If the page doesn't seem to be working, and there is a [panda](https://github.com/guardian/pan-domain-authentication)-related error in the console, you may need to run and open another tool locally (like [Composer](https://github.com/guardian/flexible-content/pull/4077/files)) in order to generate the required auth cookies
 
 NOTE: locally it uses the CODE AppSync API instance (since AppSync is a paid feature of localstack)
 


### PR DESCRIPTION
Pinboard auth won't work unless you have a [panda](https://github.com/guardian/pan-domain-authentication) cookie generated by another tool locally. Mention that requirement in the readme.

