### PR TITLE
add instructions for managing email groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ Note, `shared/graphql/schema.graphql` is also used in CDK to form part of the Cl
 Occasionally you may want to test the GraphQL queries/mutations directly from the AWS Console. You for which you will need an auth token, you can generate these by running `yarn generate-appsync-auth-token` in the root of the project and selecting CODE or PROD from the prompt.
 
 ## Maintenance Tasks
- -  [managing the email groups in the messaging UI](./users-refresher-lambda/README.md#managing-email-groups)
+
+- [managing the email groups in the messaging UI](./users-refresher-lambda/README.md#managing-email-groups)

--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ Note, `shared/graphql/schema.graphql` is also used in CDK to form part of the Cl
 ### Testing queries/mutations from AppSync area of AWS Console (in the browser)
 
 Occasionally you may want to test the GraphQL queries/mutations directly from the AWS Console. You for which you will need an auth token, you can generate these by running `yarn generate-appsync-auth-token` in the root of the project and selecting CODE or PROD from the prompt.
+
+## Maintenance Tasks
+ -  [managing the email groups in the messaging UI](./users-refresher-lambda/README.md#managing-email-groups)

--- a/users-refresher-lambda/README.md
+++ b/users-refresher-lambda/README.md
@@ -19,19 +19,22 @@ On the daily 'full run' we also load the map of groups (_key_: a 'shorthand' for
 
 The set email groups that can be messaged from Pinboard is defined in the AWS Param Store, as mentioned above. To edit the list, you will need AWS console access for the "Workflow" account in [Janus](https://janus.gutools.co.uk/).
 
-From the AWS console, open the *Parameter Store* and find the entry for pinboard groups. There are separate entries for CODE and PROD. The value of the parameter is a JSON string in this format:
+From the AWS console, open the _Parameter Store_ and find the entry for pinboard groups. There are separate entries for CODE and PROD. The value of the parameter is a JSON string in this format:
+
 ```JSON
 {
-"digicms": "digitalcms.dev@guardian.co.uk", 
+"digicms": "digitalcms.dev@guardian.co.uk",
 "pinboardHELP": "pinboard@guardian.co.uk"
 }
 ```
 
 The keys in the object are the display name shown in the Pinboard UI, the values are the email address for the group. When updating the value, please note:
- - On CODE we use "pinboard@guardian.co.uk" as the email address for all groups except "digitalcms.dev@guardian.co.uk". This is so messages on CODE pinboard are not sent to the real recipients
- - In JSON, the last entry in an object must NOT have a trailing comma
 
-  The groups are updated in the application once per day on the daily 'full run' mentioned above - but you can trigger an update after making your change by:
-   - opening the *lambda* menu from the AWS console ("Workflow" account)
-   - open the lambda (`pinboard-users-refresher-lambda-PROD` or `pinboard-users-refresher-lambda-CODE`) from the list
-   - from the *Test* tab, use the "Test" button to invoke the function (the payload sent to the lambda should be an empty object)
+- On CODE we use "pinboard@guardian.co.uk" as the email address for all groups except "digitalcms.dev@guardian.co.uk". This is so messages on CODE pinboard are not sent to the real recipients
+- In JSON, the last entry in an object must NOT have a trailing comma
+
+The groups are updated in the application once per day on the daily 'full run' mentioned above - but you can trigger an update after making your change by:
+
+- opening the _lambda_ menu from the AWS console ("Workflow" account)
+- open the lambda (`pinboard-users-refresher-lambda-PROD` or `pinboard-users-refresher-lambda-CODE`) from the list
+- from the _Test_ tab, use the "Test" button to invoke the function (the payload sent to the lambda should be an empty object)

--- a/users-refresher-lambda/README.md
+++ b/users-refresher-lambda/README.md
@@ -14,3 +14,24 @@ If people no longer have Pinboard permission, it sets the `isMentionable` proper
 This User information serves various purposes, such as populating the list of people available to 'mention', as well as acting as a lookup for resolving people's names and avatars in the display of each item (meaning we only need to store `userEmail` against each row in the `Item` table, rather than repeating all that metadata for every single message).
 
 On the daily 'full run' we also load the map of groups (_key_: a 'shorthand' for the group, _value_: any email address associated with the group) from the AWS Param Store, then for each we lookup the group details (via `groups.get` call) and the group members (via `members.list` call) and write to the `Group` and `GroupMember` tables respectively.
+
+### Managing email groups
+
+The set email groups that can be messaged from Pinboard is defined in the AWS Param Store, as mentioned above. To edit the list, you will need AWS console access for the "Workflow" account in [Janus](https://janus.gutools.co.uk/).
+
+From the AWS console, open the *Parameter Store* and find the entry for pinboard groups. There are separate entries for CODE and PROD. The value of the parameter is a JSON string in this format:
+```JSON
+{
+"digicms": "digitalcms.dev@guardian.co.uk", 
+"pinboardHELP": "pinboard@guardian.co.uk"
+}
+```
+
+The keys in the object are the display name shown in the Pinboard UI, the values are the email address for the group. When updating the value, please note:
+ - On CODE we use "pinboard@guardian.co.uk" as the email address for all groups except "digitalcms.dev@guardian.co.uk". This is so messages on CODE pinboard are not sent to the real recipients
+ - In JSON, the last entry in an object must NOT have a trailing comma
+
+  The groups are updated in the application once per day on the daily 'full run' mentioned above - but you can trigger an update after making your change by:
+   - opening the *lambda* menu from the AWS console ("Workflow" account)
+   - open the lambda (`pinboard-users-refresher-lambda-PROD` or `pinboard-users-refresher-lambda-CODE`) from the list
+   - from the *Test* tab, use the "Test" button to invoke the function (the payload sent to the lambda should be an empty object)


### PR DESCRIPTION
## What does this change?

Adds documentation about how to update the email groups available to message via pinboard.

The instructions are maybe excessively specific and might become outdated if there are major changes to the AWS console.