### PR TITLE
add 1:1 (Square) as a suggestible ratio for composer trail images

### DIFF
--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -20,6 +20,7 @@ export const SUGGEST_ALTERNATE_CROP_QUERY_SELECTOR =
 const SUGGESTIBLE_CROP_RATIOS = {
   "5:4": "Landscape",
   "4:5": "Portrait",
+  "1:1": "Square",
 };
 
 const gridTopLevelDomain = window.location.hostname.endsWith(".gutools.co.uk")


### PR DESCRIPTION
Small tweak following on from #312 , to add `1:1` as a suggestible crop ratio (to support highlights containers for example), which makes it look like so (in composer)...
<img width="338" alt="image" src="https://github.com/user-attachments/assets/4ded15ef-d11f-484f-a73b-f2ba25d0e024" />

