### PR TITLE
touch of extra logging on server and client to hopefully diagnose issues loading in fronts in AUS

### DIFF
--- a/bootstrapping-lambda/src/server.ts
+++ b/bootstrapping-lambda/src/server.ts
@@ -121,6 +121,12 @@ server.get(
 
     const appSyncConfig = await generateAppSyncConfig(request.userEmail!, s3);
 
+    console.log(
+      request.userEmail,
+      "successfully requested pinboard.loader.js ON",
+      request.headers.referer
+    );
+
     response.send(
       loaderTemplate(
         {

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -397,6 +397,8 @@ export const PinBoardApp = ({
     [me?.featureFlags]
   );
   useEffect(() => {
+    console.log("Pinboard running", { featureFlags });
+
     me?.email &&
       consumeFeatureFlagQueryParamsAndUpdateAccordingly(
         apolloClient,


### PR DESCRIPTION
Currently investigating pinboard not loading in the fronts tool for users in AUS. So added some server-side logging to see what domain and which user successfully loads the `pinboard.loader.js` script and then some logging in the client side to see what the featureFlags values are (which affected users can screenshot and send to us).

✅  tested on CODE