### PR TITLE
explicitly send users to the push-notifications index.html page, as trailing slashes cause problems

### DIFF
--- a/client/src/pushNotificationPreferences.tsx
+++ b/client/src/pushNotificationPreferences.tsx
@@ -15,7 +15,7 @@ const toolsDomain = hostname.includes(".local.")
   ? "code.dev-gutools.co.uk"
   : "gutools.co.uk";
 
-export const desktopNotificationsPreferencesUrl = `https://pinboard.${toolsDomain}/push-notifications/`;
+export const desktopNotificationsPreferencesUrl = `https://pinboard.${toolsDomain}/push-notifications/index.html`;
 
 export const PushNotificationPreferencesOpener = ({
   hasWebPushSubscription,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When switching to the updated version of serverless-express, they have included breaking changes around how the path is built. It now uses the captured/proxy part of the route, which will not persist a trailing slash. This means that a request for `/push-notifications/` will be received by express.static as `/push-notifications`, which will return a redirect to `/push-notifications/`. But that's where the browser already is, so that'll just cause the same redirection to be issued, again, and again, and again...

This is a known issue in the new serverless-express: https://github.com/CodeGenieApp/serverless-express/issues/391, which has been attempted to be fixed previously: https://github.com/CodeGenieApp/serverless-express/pull/441, but of course a fix for a breaking change is itself a breaking change, and if it comes too slowly then users will have already built around the different behaviour, and clamour for a revert to fix their apps: https://github.com/CodeGenieApp/serverless-express/pull/455. Sigh.

This seems almost impossible to fix now, so opt out of it entirely by not deliberately sending a request for a trailing slash: return to the early web and make visible requests for an `index.html`.

## How to test

Deploy to CODE and attempt to toggle your notification settings.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
