### PR TITLE
[fronts] just display total count in the per card pinboard button (with more detail in the tooltip/`title`)

### DIFF
--- a/client/src/buttonInOtherTools.tsx
+++ b/client/src/buttonInOtherTools.tsx
@@ -8,12 +8,14 @@ interface ButtonInOtherToolsProps {
   iconAtEnd?: true;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   extraCss?: SerializedStyles;
+  title?: string;
 }
 export const ButtonInOtherTools = ({
   children,
   iconAtEnd,
   onClick,
   extraCss,
+  title,
 }: PropsWithChildren<ButtonInOtherToolsProps>) => (
   <button
     onClick={onClick}
@@ -30,6 +32,7 @@ export const ButtonInOtherTools = ({
       color: ${pinMetal};
       ${extraCss};
     `}
+    title={title}
   >
     {iconAtEnd && children}
     <PinIcon

--- a/client/src/fronts/frontsPinboardArticleButton.tsx
+++ b/client/src/fronts/frontsPinboardArticleButton.tsx
@@ -12,6 +12,7 @@ import { pinboard } from "../../colours";
 import { neutral } from "@guardian/source-foundations";
 import { agateSans } from "../../fontNormaliser";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "../types/Telemetry";
+import { SvgSpinner } from "@guardian/source-react-components";
 
 interface FrontsPinboardArticleButtonProps {
   maybePinboardData: PinboardData | undefined;
@@ -59,6 +60,18 @@ export const FrontsPinboardArticleButton = ({
     maybeItemCounts?.totalCropCount,
   ]);
 
+  const tooltipText = (() => {
+    if (!hasCountsLoaded) {
+      return "Loading item counts...";
+    }
+    if (!maybePinboardData) {
+      return "This piece is not tracked in workflow, which is required to chat and share assets (such as crops) via Pinboard.";
+    }
+    if (maybeItemCounts) {
+      return `${maybeItemCounts.totalCount} items with ${maybeItemCounts.totalCropCount} crops (${maybeItemCounts.fiveByFourCount} at 5:4 and ${maybeItemCounts.fourByFiveCount} at 4:5)`;
+    }
+  })();
+
   return (
     <root.span>
       <ButtonInOtherTools
@@ -67,7 +80,6 @@ export const FrontsPinboardArticleButton = ({
           background-color: ${maybePinboardData
             ? pinboard[500]
             : neutral["60"]};
-          // TODO fix line-height when button text wraps over multiple lines
         `}
         onClick={(event) => {
           event.stopPropagation();
@@ -79,26 +91,13 @@ export const FrontsPinboardArticleButton = ({
             );
           }
         }}
+        title={tooltipText}
       >
-        {!maybePinboardData && "Not tracked in workflow"}
-        {maybePinboardData && !hasCountsLoaded && <em>loading...</em>}
-        {maybePinboardData && hasCountsLoaded && !maybeItemCounts && "0 items"}
-        {maybeItemCounts && (
-          <>
-            {maybeItemCounts.totalCount}
-            &nbsp;items
-            {maybeItemCounts.totalCropCount > 0 && (
-              <>
-                &nbsp;with&nbsp;
-                {maybeItemCounts.totalCropCount}
-                &nbsp;crops
-                <wbr /> ({maybeItemCounts.fiveByFourCount}
-                &nbsp;at&nbsp;5:4&nbsp;and&nbsp;
-                {maybeItemCounts.fourByFiveCount}&nbsp;at&nbsp;4:5)
-              </>
-            )}
-          </>
-        )}
+        {!hasCountsLoaded && <SvgSpinner size="xsmall" />}
+        {hasCountsLoaded && !maybePinboardData && "N/A"}
+        {maybePinboardData &&
+          hasCountsLoaded &&
+          (maybeItemCounts?.totalCount || 0)}
       </ButtonInOtherTools>
 
       <div


### PR DESCRIPTION
## Screenshots
#### Loading
_Loads too quickly to capture a screenshot, but now we use the xsmall loading spinner._

#### Not tracked in workflow
<img width="400" alt="image" src="https://github.com/user-attachments/assets/bb6b9124-6533-4dd9-a29f-6a5505ea3592" />
<img width="198" alt="image" src="https://github.com/user-attachments/assets/5077b2c1-58d0-4b05-8d01-7e782161f006" />

#### With some messages & crops
<img width="390" alt="image" src="https://github.com/user-attachments/assets/efb613cc-5bb4-455e-b7a1-8ccb71449d6e" />
<img width="198" alt="image" src="https://github.com/user-attachments/assets/cbe26517-a128-4cb3-b9aa-4c83740129e9" />
 


