### PR TITLE
Change code owner to workflow and collaboration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 ## code changes will send PR to following users
-* @guardian/digital-cms @twrichards
+* @guardian/workflow-and-collaboration @twrichards


### PR DESCRIPTION
## What does this change?

The [Workflow and Collaboration team](https://github.com/orgs/guardian/teams/workflow-and-collaboration) is now responsible for this repository (e.g. for health upgrade etc.). As such, we think it makes sense to narrow the code owner from digital-cms (which is quite a large group) to workflow and collaboration.

## How to test

- confirm that Github flags the code owners file as valid
- after merge, open a new PR and confirm that Workflow and Collaboration are requested for review instead of Digital CMS

## How can we measure success?

- people get fewer irrelevant github emails