### PR TITLE
trigger email-lambda immediately for individual mentions too (and simplify/refactor out the missed mentions logic)

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -24,9 +24,8 @@ Object {
       "GuCname",
       "GuCname",
       "GuCname",
-      "GuScheduledLambda",
+      "GuLambdaFunction",
       "GuLambdaErrorPercentageAlarm",
-      "GuAlarm",
       "GuAlarm",
     ],
     "gu:cdk:version": "60.1.3",
@@ -1376,44 +1375,6 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "EmailLambdaEmailLambdarate5minutes0AllowEventRulePinBoardStackTESTEmailLambdaA8A9241C239D7601": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "EmailLambda93E95E21",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::GetAtt": Array [
-            "EmailLambdaEmailLambdarate5minutes0E68F318E",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "EmailLambdaEmailLambdarate5minutes0E68F318E": Object {
-      "Properties": Object {
-        "Description": "Run every 5 minutes to ensure emails get sent out promptly (and not too huge batches, which might hit rate limits)",
-        "ScheduleExpression": "rate(5 minutes)",
-        "State": "ENABLED",
-        "Targets": Array [
-          Object {
-            "Arn": Object {
-              "Fn::GetAtt": Array [
-                "EmailLambda93E95E21",
-                "Arn",
-              ],
-            },
-            "Id": "Target0",
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
     "EmailLambdaErrorPercentageAlarmForLambda75B2E289": Object {
       "Properties": Object {
         "ActionsEnabled": true,
@@ -1561,84 +1522,6 @@ Object {
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EmailLambdaRaceConditionAlarmB1E6FE09": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:aws:sns:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                Object {
-                  "Ref": "AWS::AccountId",
-                },
-                ":Cloudwatch-Alerts",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "This occurs when the email-lambda has been invoked directly from RDS, being passed the ID of an item with group mentions, yet when querying the database for the item, it has no group mentions to email about. This is unexpected and indicates a race condition.",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "EvaluationPeriods": 1,
-        "MetricName": "EmailLambdaRaceCondition",
-        "Namespace": "Pinboard/TEST",
-        "Period": 300,
-        "Statistic": "Average",
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "pinboard",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "60.1.3",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/pinboard",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "workflow",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 1,
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EmailLambdaRaceConditionMetricFilterC63DB9EC": Object {
-      "Properties": Object {
-        "FilterPattern": "has no group mentions to email about. This is unexpected.",
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "EmailLambda93E95E21",
-              },
-            ],
-          ],
-        },
-        "MetricTransformations": Array [
-          Object {
-            "MetricName": "EmailLambdaRaceCondition",
-            "MetricNamespace": "Pinboard/TEST",
-            "MetricValue": "1",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::MetricFilter",
     },
     "EmailLambdaServiceRoleCBE95916": Object {
       "Properties": Object {

--- a/email-lambda/README.md
+++ b/email-lambda/README.md
@@ -1,17 +1,14 @@
 ## `email-lambda`
 
-As a fallback for users without desktop notifications turned-on etc. we'd like users who miss key messages (individual mentions currently, but group mentions and potentially other ) to hear about them via a communication channels they're very familiar with and unlikely to ignore - email.
+As a fallback for users without desktop notifications turned-on etc. we'd like users who are 'mentioned' (both individually or group) to hear about them via a communication channels they're very familiar with and unlikely to ignore - email.
 
-This lambda runs every 5 minutes and does the following...
+This lambda is invoked directly from a DB trigger and does the following...
 
-1. queries the DB for
-   - items with individual mentions which have remained unread for more than an hour (by those mentioned) and haven't had `isEmailEvaluated` set to true.
-   - items where `Central Production` is group mentioned and haven't had `isEmailEvaluated` set to true.
-1. collates all items into per-user data structure, and then per-pinboard within that
+1. queries the DB for additional information relating to the item it has been invoked with
+1. collates into per-user data structure (multiple for group mentions)
 1. looks-up the working titles and headlines from workflow (by invoking [`workflow-bridge-lambda`](../workflow-bridge-lambda))
 1. loops through the users, sending them an email (using [AWS Simple Email Service (SES)](https://aws.amazon.com/ses/)) from the relevant pinboard domain - `mentions@pinboard.code.dev-gutools.co.uk` or `mentions@pinboard.gutools.co.uk`
    - These domains are registered as 'SES verified identities' and DNS validated automatically via CDK code 🎉 .
    - The email is rendered using `preact` (like the client) but using `style` attribute rather than emotion, for best compatibility with email clients.
-1. sets `isEmailEvaluated` to true for the items it has emailed about
 
 Note that CODE emails are flagged as `External` - because `code.dev-gutools.co.uk` is not an alias in gSuite, but `gutools.co.uk` is.

--- a/shared/database/local/runDatabaseSetup.ts
+++ b/shared/database/local/runDatabaseSetup.ts
@@ -87,6 +87,8 @@ const runSetupTriggerSqlFile = (
         ),
     "add featureFlags column to User table": () =>
       runSetupSqlFile(sql, "020-AddFeatureFlagsColumnToUserTable.sql"),
+    "drop isEmailEvaluated column from Item table": () =>
+      runSetupSqlFile(sql, "021-DropIsEmailEvaluatedColumnFromItemTable.sql"),
   };
 
   const allSteps = async () => {

--- a/shared/database/local/setup/019-TriggerEmailLambdaAfterItemInsert.sql
+++ b/shared/database/local/setup/019-TriggerEmailLambdaAfterItemInsert.sql
@@ -4,7 +4,8 @@ CREATE OR REPLACE FUNCTION invokeEmailLambda()
 AS
 $$
 BEGIN
-    IF NEW."groupMentions" IS NOT NULL AND NEW."groupMentions" != '{}' THEN
+    IF (NEW."groupMentions" IS NOT NULL AND NEW."groupMentions" != '{}')
+       OR (NEW."mentions" IS NOT NULL AND NEW."mentions" != '{}') THEN
         PERFORM * FROM aws_lambda.invoke(
                 aws_commons.create_lambda_function_arn(
                         '$lambdaFunctionName',

--- a/shared/database/local/setup/021-DropIsEmailEvaluatedColumnFromItemTable.sql
+++ b/shared/database/local/setup/021-DropIsEmailEvaluatedColumnFromItemTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Item" DROP COLUMN "isEmailEvaluated";


### PR DESCRIPTION
Based on feedback as people use pinboard more (thanks to #312) people would like to be emailed immediately for individual mentions (just like teams are emailed immediately for group mentions). 

Overall this is a major simplification as it means we can eliminate the scheduling and logic to find/aggregate individual mentions which have gone unread for an hour.

**_I recommend reviewing with whitespace changes hidden_** 
<img width="203" alt="image" src="https://github.com/user-attachments/assets/13c34c0a-111b-4949-a9e8-1cd2790c4462" />

## DB changes applied to...
#### CODE
- [x] re-run `019-TriggerEmailLambdaAfterItemInsert.sql` to update the trigger (to also include individual mentions)
- [ ] AFTER the `email-lambda` is deployed, then run `021-DropIsEmailEvaluatedColumnFromItemTable.sql`
#### PROD
- [ ] re-run `019-TriggerEmailLambdaAfterItemInsert.sql` to update the trigger (to also include individual mentions)
- [ ] AFTER the `email-lambda` is deployed, then run `021-DropIsEmailEvaluatedColumnFromItemTable.sql`