### PR TITLE
add more tolerance to the `pinboard-bootstrapping-lambda-api-CODE 5XX errors` alarm given CODE invocations are fewer and more sporadic

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -3940,7 +3940,7 @@ $util.toJson($ctx.result)",
             "Value": "pinboard-bootstrapping-lambda-api-TEST",
           },
         ],
-        "EvaluationPeriods": 2,
+        "EvaluationPeriods": 6,
         "MetricName": "5XXError",
         "Namespace": "AWS/ApiGateway",
         "OKActions": Array [

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -724,7 +724,7 @@ export class PinBoardStack extends GuStack {
       }),
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       threshold: 0.05,
-      evaluationPeriods: 2,
+      evaluationPeriods: isPROD ? 2 : 6, // CODE invocations are fewer and more sporadic so let's have more tolerance there
       actionsEnabled: true,
       okAction: true,
     });


### PR DESCRIPTION
thanks to a nudge from @emdash-ie I was reminded that the 5XX alarm for CODE bootstrapping-lambda (introduced in #316 ) occasionally fires and we don't want people to ignore it - so this change now only fires the alarm if errors for longer (30mins CODE vs 10mins for PROD now)