### PR TITLE
re-use database connections across lambda invocations - to avoid rate limiting

### DIFF
--- a/archiver-lambda/src/index.ts
+++ b/archiver-lambda/src/index.ts
@@ -97,7 +97,5 @@ export const handler = async () => {
   } catch (e) {
     console.error(e);
     throw e;
-  } finally {
-    await sql.end();
   }
 };

--- a/database-bridge-lambda/src/index.ts
+++ b/database-bridge-lambda/src/index.ts
@@ -85,18 +85,14 @@ export const handler = async (
   payload: MetricRequest | AppSyncResolverEvent<unknown, unknown>
 ) => {
   const sql = await getDatabaseConnection();
-  try {
-    if (isMetricRequest(payload)) {
-      console.log("metric payload", payload);
-      return await getMetrics(sql, payload);
-    } else {
-      const args = payload.arguments as never;
-      const userEmail: string = (payload.identity as AppSyncIdentityLambda)
-        .resolverContext.userEmail;
-      const databaseOperation = payload.info.fieldName as DatabaseOperation;
-      return await run(sql, databaseOperation, args, userEmail);
-    }
-  } finally {
-    await sql.end();
+  if (isMetricRequest(payload)) {
+    console.log("metric payload", payload);
+    return await getMetrics(sql, payload);
+  } else {
+    const args = payload.arguments as never;
+    const userEmail: string = (payload.identity as AppSyncIdentityLambda)
+      .resolverContext.userEmail;
+    const databaseOperation = payload.info.fieldName as DatabaseOperation;
+    return await run(sql, databaseOperation, args, userEmail);
   }
 };

--- a/email-lambda/src/index.ts
+++ b/email-lambda/src/index.ts
@@ -188,7 +188,5 @@ export const handler = async (maybeSendImmediatelyDetail?: {
   } catch (e) {
     console.error(e);
     throw e;
-  } finally {
-    await sql.end();
   }
 };

--- a/shared/database/databaseConnection.ts
+++ b/shared/database/databaseConnection.ts
@@ -4,7 +4,36 @@ import { DATABASE_PORT, DATABASE_USERNAME, DATABASE_NAME } from "./database";
 import { getEnvironmentVariableOrThrow } from "../environmentVariables";
 import { Signer } from "@aws-sdk/rds-signer";
 
+const TEN_MINS_IN_MILLIS = 10 * 60 * 1000;
+
+interface TimestampedConnectionPool {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  sql: postgres.Sql<{}>;
+  createdAt: number; // epoch millis
+}
+
+let maybeConnectionPool: TimestampedConnectionPool | null = null;
+
 export async function getDatabaseConnection() {
+  const now = Date.now();
+  const tenMinsAgoEpochMillis = now - TEN_MINS_IN_MILLIS;
+  if (
+    maybeConnectionPool &&
+    maybeConnectionPool.createdAt > tenMinsAgoEpochMillis
+  ) {
+    console.log(
+      `Reusing existing database connection (${
+        (now - maybeConnectionPool.createdAt) / 1000
+      } seconds old)`
+    );
+    return maybeConnectionPool.sql;
+  } else if (maybeConnectionPool) {
+    console.log(
+      "Existing connection pool older than 10mins, closing before creating a fresh pool..."
+    );
+    await maybeConnectionPool.sql.end();
+  }
+
   const databaseHostname = getEnvironmentVariableOrThrow("databaseHostname");
 
   const basicConnectionDetails = {
@@ -23,11 +52,21 @@ export async function getDatabaseConnection() {
       `\nIAM Token to use as DB password (if you want to connect from command line, IntelliJ etc.)\n${iamToken}\n`
     );
 
-  return postgres({
-    ...basicConnectionDetails,
-    hostname: IS_RUNNING_LOCALLY ? "localhost" : databaseHostname,
-    database: DATABASE_NAME,
-    password: iamToken,
-    ssl: "require",
-  });
+  maybeConnectionPool = {
+    sql: postgres({
+      ...basicConnectionDetails,
+      hostname: IS_RUNNING_LOCALLY ? "localhost" : databaseHostname,
+      database: DATABASE_NAME,
+      password: iamToken,
+      ssl: "require",
+      onclose: (connectionNumber) =>
+        console.log(`Connection (#${connectionNumber}) closed`),
+      idle_timeout: 60, // seconds
+    }),
+    createdAt: Date.now(),
+  };
+
+  console.log("Created new database connection pool");
+
+  return maybeConnectionPool.sql;
 }

--- a/users-refresher-lambda/src/index.ts
+++ b/users-refresher-lambda/src/index.ts
@@ -242,7 +242,5 @@ export const handler = async ({
   } catch (e) {
     console.error(e);
     throw e;
-  } finally {
-    await sql.end();
   }
 };


### PR DESCRIPTION
Since March 10th many more people have been using Pinboard (predominantly via the functionality in #312) and as such we've started hitting `The IAM authentication failed because of too many competing requests.` error in `database-bridge-lambda` around 100 times per day (a very small percentage of the 300k invocations per day).

After contacting AWS Support, there appears to be no way to raise the limit and so we had the choice of either using username/password (rather than IAM tokens) as this has a higher limit OR trying to re-use connections. It would be a shame to move away from IAM auth and re-using connections seemed like the right thing to do.

This PR does just that, in the shared logic for `createDatabaseConnection` we now hold the instantiated `postgres.Sql` instance ([already natively a connection pool](https://www.npmjs.com/package/postgres#the-connection-pool)) in a variable for re-use between invocations of a hot lambda, and forcibly recycle it after 10mins of use (since the IAM token lasts 15mins). We also introduce a 60s idle_timeout for good measure. We now log the re-use vs fresh connection for some visibility - **which shows this seems to be working nicely in CODE 🎉 **.

_I had hoped that this would mean we could eliminate the RDS Proxy (which costs over $500 per year for CODE & PROD combined), but as @andrew-nowak rightly points out, the proxy is still acting as a buffer given `database-bridge-lambda` can exceed 500 concurrent invocations, under heavy load - something which RDS instance itself couldn't handle AFAIK._