### PR TITLE
fix hover position for `SuggestAlternateCrops` component, for interactive articles for example

### DIFF
--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -74,10 +74,13 @@
 
     <h4>Composer Buttons etc. (under trail image in furniture)</h4>
     <em>Requires preselected pinboard (like in composer)</em>
-    <div
-      style="background: #f6f6f6; padding-left: 420px; display: inline-block"
-    >
-      <div style="width: 195px">
+    <div style="background: #f6f6f6; display: inline-block">
+      <div style="padding-left: 420px; width: 195px">
+        <pinboard-suggest-alternate-crops
+          data-media-id="d6518ba44eb272830b779e4ed6356482007d4536"
+        ></pinboard-suggest-alternate-crops>
+      </div>
+      <div>
         <pinboard-suggest-alternate-crops
           data-media-id="d6518ba44eb272830b779e4ed6356482007d4536"
         ></pinboard-suggest-alternate-crops>

--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -175,13 +175,16 @@ export const SuggestAlternateCrops = ({
 
   const AlreadySuggestedCropsForRatio = ({
     customRatio,
+    clientX,
   }: {
     customRatio: string;
+    clientX: number;
   }) => {
     if (!cropsOnPreselectedPinboard) return null;
     const cropsMatchingRatio = cropsOnPreselectedPinboard.filter(
       ([_]) => _.aspectRatio === customRatio
     );
+    const shouldDisplayHoverOnLeft = clientX > 350;
     return (
       <div
         css={css`
@@ -194,6 +197,8 @@ export const SuggestAlternateCrops = ({
           user-select: none;
           text-align: center;
           &:hover {
+            box-shadow: ${shouldDisplayHoverOnLeft ? -5 : 5}px 0 0
+              ${cropsMatchingRatio.length ? pinboard["500"] : "transparent"};
             background-color: ${cropsMatchingRatio.length
               ? pinboard["500"]
               : "transparent"};
@@ -211,9 +216,12 @@ export const SuggestAlternateCrops = ({
             css={css`
               display: none;
               position: absolute;
-              left: 0;
+              ${shouldDisplayHoverOnLeft ? "left" : "right"}: -5px;
               bottom: 50%;
-              transform: translate(-100%, 50%);
+              transform: translate(
+                ${shouldDisplayHoverOnLeft ? -100 : 100}%,
+                50%
+              );
               z-index: 9999;
               padding: 5px;
               border-radius: 3px;
@@ -260,9 +268,10 @@ export const SuggestAlternateCrops = ({
         ReactDOM.createPortal(
           <div>
             <label className="sub-label">Suggest crops for Fronts</label>
+            <br />
             <root.div
               css={css`
-                display: flex;
+                display: inline-flex;
                 flex-direction: column;
                 margin: 5px 0;
                 align-items: center;
@@ -286,6 +295,7 @@ export const SuggestAlternateCrops = ({
                       </ButtonInOtherTools>
                       <AlreadySuggestedCropsForRatio
                         customRatio={customRatio}
+                        clientX={htmlElement.getBoundingClientRect().x}
                       />
                     </>
                   )


### PR DESCRIPTION
If the `SuggestAlternateCrops` component appears within the left 350px of the screen (e.g. furniture of interactive pieces) then display the hover tooltip of existing suggested crops on the right instead - as it was off the edge of the screen before.