### PR TITLE
MAM suggest crops improvements

### DIFF
--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -84,6 +84,7 @@ export const SuggestAlternateCrops = ({
     cropsOnPreselectedPinboard,
     featureFlags,
     setError,
+    openInTool,
   } = useGlobalStateContext();
 
   const sendTelemetryEvent = useContext(TelemetryContext);
@@ -191,7 +192,7 @@ export const SuggestAlternateCrops = ({
           position: relative;
           width: 100%;
           ${agateSans.xxsmall()};
-          color: ${pinMetal};
+          color: ${openInTool === "media-atom-maker" ? "white" : pinMetal};
           margin-top: 2px;
           margin-bottom: 5px;
           user-select: none;

--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -267,7 +267,13 @@ export const SuggestAlternateCrops = ({
       {alternateCropSuggestionElements.map((htmlElement) =>
         ReactDOM.createPortal(
           <div>
-            <label className="sub-label">Suggest crops for Fronts</label>
+            <label
+              css={css`
+                font-weight: bold;
+              `}
+            >
+              Suggest crops for Fronts
+            </label>
             <br />
             <root.div
               css={css`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Improves the contrast of the "N crops already suggested" text in MAM, and renders the "Suggest crops for Fronts" label in bold

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

before:
![image](https://github.com/user-attachments/assets/568f6085-7a10-4584-9a41-b3e4547dea48)

after:
![image](https://github.com/user-attachments/assets/95efdafe-c515-497d-a886-1ad99ef7e250)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
