### PR TITLE
specify crop types without using custom ratio

### DIFF
--- a/client/src/fronts/suggestAlternateCrops.tsx
+++ b/client/src/fronts/suggestAlternateCrops.tsx
@@ -13,14 +13,15 @@ import { agateSans } from "../../fontNormaliser";
 import { pinboard, pinMetal } from "../../colours";
 import { neutral } from "@guardian/source-foundations";
 import { PINBOARD_TELEMETRY_TYPE, TelemetryContext } from "../types/Telemetry";
+import { capitalise } from "shared/util";
 
 export const SUGGEST_ALTERNATE_CROP_QUERY_SELECTOR =
   "pinboard-suggest-alternate-crops";
 
 const SUGGESTIBLE_CROP_RATIOS = {
-  "5:4": "Landscape",
-  "4:5": "Portrait",
-  "1:1": "Square",
+  "5:4": "landscape NEW",
+  "4:5": "portrait",
+  "1:1": "square",
 };
 
 const gridTopLevelDomain = window.location.hostname.endsWith(".gutools.co.uk")
@@ -64,15 +65,12 @@ export const SuggestAlternateCrops = ({
   const apolloClient = useApolloClient();
 
   const onClick = useCallback(
-    (maybeMediaId: string | undefined, cropType: string, customRatio: string) =>
-      () =>
-        setMaybeGridIframeUrl(
-          `https://media.${gridTopLevelDomain}${
-            maybeMediaId ? `/images/${maybeMediaId}/crop` : ""
-          }?cropType=${cropType}&customRatio=${cropType},${customRatio
-            .split(":")
-            .join(",")}`
-        ),
+    (maybeMediaId: string | undefined, cropType: string) => () =>
+      setMaybeGridIframeUrl(
+        `https://media.${gridTopLevelDomain}${
+          maybeMediaId ? `/images/${maybeMediaId}/crop` : ""
+        }?cropType=${cropType}`
+      ),
     []
   );
 
@@ -87,7 +85,9 @@ export const SuggestAlternateCrops = ({
           "https://"
         )}?crop=${data.id}`,
         aspectRatio: data.specification.aspectRatio,
-        cropType: SUGGESTIBLE_CROP_RATIOS[data.specification.aspectRatio],
+        cropType: capitalise(
+          SUGGESTIBLE_CROP_RATIOS[data.specification.aspectRatio]
+        ),
       };
       if (isPinboardData(preselectedPinboard)) {
         const createItemInput: CreateItemInput = {
@@ -263,11 +263,7 @@ export const SuggestAlternateCrops = ({
                   ([customRatio, cropType]) => (
                     <>
                       <ButtonInOtherTools
-                        onClick={onClick(
-                          htmlElement.dataset.mediaId,
-                          cropType,
-                          customRatio
-                        )}
+                        onClick={onClick(htmlElement.dataset.mediaId, cropType)}
                       >
                         Suggest an alternate {customRatio} crop
                       </ButtonInOtherTools>

--- a/shared/util.ts
+++ b/shared/util.ts
@@ -1,6 +1,6 @@
 import { WithNames } from "./types/withNames";
 
-const capitalise = (str: string) =>
+export const capitalise = (str: string) =>
   str &&
   str
     .split("-")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

All of these crop types are known to grid, so we can refer to them by name. This will then also make the new circle guideline functionality on 1:1 crops work as expected.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
