### PR TITLE
only perform the `seenItem` mutation ONCE for the last item (and only if it hasn't already been seen)

### DIFF
--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -141,17 +141,25 @@ export const ScrollableItems = ({
 
   const sendTelemetryEvent = useContext(TelemetryContext);
 
+  const [itemIdToSetAsLastSeen, setItemIdToSetAsLastSeen] = useState<
+    string | null
+  >(null);
+
   const seenLastItem = () => {
-    // don't keep sending mutations if everyone already knows we've seen it
+    maybeLastItem && setItemIdToSetAsLastSeen(maybeLastItem.id);
+  };
+
+  // the useEffect below ensures the seenItem mutation is called only once for the last item (and only if it hasn't already been seen)
+  useEffect(() => {
     if (
-      maybeLastItem &&
-      maybeLastItem.id !== lastItemSeenByUserLookup[userEmail]?.itemID
+      itemIdToSetAsLastSeen &&
+      itemIdToSetAsLastSeen !== lastItemSeenByUserLookup[userEmail]?.itemID
     ) {
       seenItem({
         variables: {
           input: {
             pinboardId,
-            itemID: maybeLastItem.id,
+            itemID: itemIdToSetAsLastSeen,
           },
         },
       });
@@ -159,7 +167,7 @@ export const ScrollableItems = ({
         pinboardId,
       });
     }
-  };
+  }, [itemIdToSetAsLastSeen]);
 
   useEffect(() => {
     if (isScrolledToBottom && hasBrowserFocus) {


### PR DESCRIPTION
For as long as I can remember the `seenItem` mutation would be called a little overzealously (because of various phases of rendering etc. given its based on scroll position etc.) before the updated `lastItemSeenByUser` would come back via the subscription - aside from being a little wasteful (and over-reporting in telemetry 😢 ) this didn't cause any real problems. However, since https://github.com/guardian/pinboard/pull/330 where we trigger `getItemCounts` and `getGroupPinboardIds` based on a user's `totalOfMyOwnOnSeenItemsReceivedViaSubscription` (given this affects unread count etc.) PLUS the fact usage of pinboard has increased hugely since the shift to 5:4 imagery (given alternate crop suggesting functionality added in #312) ... we've been seeing huge spikes in calls to `getGroupPinboardIds` which correlate with calls to 'seenItem' mutation... 
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/e79a1a70-791c-4bf3-9f52-e3c9b9d5f09c" />
(note the different Y axis scales left & right)
... these big spikes in turn have been causing occasional `The IAM authentication failed because of too many competing requests.` errors in `database-bridge-lambda` (albeit vastly reduced since https://github.com/guardian/pinboard/pull/352).

Since it was wasteful anyway (and problematic for telemetry) to call `seenItem` mutation any more than necessary, this PR should fix that using an additional bit of state within the `ScrollableItems` component to store the id that we'd like to set as the last seen by the user, then we now execute the mutation only when that state changes, this avoids sending the same value multiple times, this should therefore also:

1. avoid the occasional errors from `database-bridge-lambda` (which must be problematic for users)
3. improve the integirty of the telemetry data for the `MESSAGE_SEEN` event (currently most frequent event)
4. save at least few dollars per week 🤑 