### PR TITLE
Switch to workflow datastore in new VPC

### DIFF
--- a/cdk/lib/__snapshots__/stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/stack.test.ts.snap
@@ -5215,7 +5215,7 @@ $util.toJson($ctx.result)",
             "STACK": "workflow",
             "STAGE": "TEST",
             "WORKFLOW_DATASTORE_LOAD_BALANCER_DNS_NAME": Object {
-              "Fn::ImportValue": "WorkflowDatastoreLoadBalancerDNSName-TEST",
+              "Fn::ImportValue": "WorkflowDatastoreLoadBalancerDNSNameNewVpc-TEST",
             },
           },
         },
@@ -5255,14 +5255,14 @@ $util.toJson($ctx.result)",
         "VpcConfig": Object {
           "SecurityGroupIds": Array [
             Object {
-              "Fn::ImportValue": "WorkflowDatastoreLoadBalancerSecurityGroupId-TEST",
+              "Fn::ImportValue": "WorkflowDatastoreLoadBalancerSecurityGroupIdNewVpc-TEST",
             },
           ],
           "SubnetIds": Object {
             "Fn::Split": Array [
               ",",
               Object {
-                "Fn::ImportValue": "WorkflowPrivateSubnetIds-TEST",
+                "Fn::ImportValue": "WorkflowPrivateSubnetIdsNewVpc-TEST",
               },
             ],
           },

--- a/cdk/lib/stack.ts
+++ b/cdk/lib/stack.ts
@@ -170,7 +170,7 @@ export class PinBoardStack extends GuStack {
     });
 
     const workflowDatastoreVpcId = Fn.importValue(
-      `WorkflowDatastoreLoadBalancerSecurityGroupVpcId-${this.stage}`
+      `WorkflowDatastoreLoadBalancerSecurityGroupVpcIdNewVpc-${this.stage}`
     );
 
     const workflowDatastoreVPC = ec2.Vpc.fromVpcAttributes(
@@ -181,7 +181,7 @@ export class PinBoardStack extends GuStack {
         availabilityZones: Fn.getAzs(region),
         privateSubnetIds: Fn.split(
           ",",
-          Fn.importValue(`WorkflowPrivateSubnetIds-${this.stage}`)
+          Fn.importValue(`WorkflowPrivateSubnetIdsNewVpc-${this.stage}`)
         ),
       }
     );
@@ -200,7 +200,7 @@ export class PinBoardStack extends GuStack {
           STACK: this.stack,
           APP,
           [ENVIRONMENT_VARIABLE_KEYS.workflowDnsName]: Fn.importValue(
-            `WorkflowDatastoreLoadBalancerDNSName-${this.stage}`
+            `WorkflowDatastoreLoadBalancerDNSNameNewVpc-${this.stage}`
           ),
         },
         functionName: getWorkflowBridgeLambdaFunctionName(this.stage as Stage),
@@ -225,7 +225,7 @@ export class PinBoardStack extends GuStack {
             this,
             "workflow-datastore-load-balancer-security-group",
             Fn.importValue(
-              `WorkflowDatastoreLoadBalancerSecurityGroupId-${this.stage}`
+              `WorkflowDatastoreLoadBalancerSecurityGroupIdNewVpc-${this.stage}`
             )
           ),
         ],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are migrating the Workflow backend to another VPC with separated public and private subnets to address the FSBP issues on EC2 instances having public IP addresses.

We provisioned new infrastructure in the new VPC for Datastore, and produced new outputs for the VPC, security group, private subnet ID and the internal DNS name of the new load balancer.

The pull request updates the `workflow-bridge-lambda` lambda in the cloudformation stack to reference the new set of the output values.  This switch the Pinboard to the Datastore service in new VPC.

## How to test

We did a smoke test on Pinboard, sending and receiving messages via Pinboard across different apps.

## How can we measure success?

We switch all traffic to Datastore to the new VPC and we can remove the infrastructure in the old VPC.