### PR TITLE
Only call `getGroupPinboardIds` when group mentions includes one of their teams

### DIFF
--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -16,6 +16,7 @@ import {
   Claimed,
   Item,
   LastItemSeenByUser,
+  MentionHandle,
   MyUser,
 } from "../../shared/graphql/graphql";
 import {
@@ -69,7 +70,7 @@ interface GlobalStateContextShape {
   allSubscriptionClaimedItems: Item[]; // both the updated 'claimed' item and the new 'claim' item
   allSubscriptionOnSeenItems: LastItemSeenByUser[];
   totalItemsReceivedViaSubscription: number;
-  totalItemsWithGroupMentionsReceivedViaSubscription: number;
+  totalItemsWithRelevantGroupMentionsReceivedViaSubscription: number;
   totalOfMyOwnOnSeenItemsReceivedViaSubscription: number;
 
   payloadToBeSent: PayloadAndType | null;
@@ -306,8 +307,8 @@ export const GlobalStateProvider = ({
     setTotalItemsReceivedViaSubscription,
   ] = useState(0);
   const [
-    totalItemsWithGroupMentionsReceivedViaSubscription,
-    setTotalItemsWithGroupMentionsReceivedViaSubscription,
+    totalItemsWithRelevantGroupMentionsReceivedViaSubscription,
+    setTotalItemsWithRelevantGroupMentionsReceivedViaSubscription,
   ] = useState(0);
 
   const [allSubscriptionItems, setAllSubscriptionItems] = useState<Item[]>([]);
@@ -315,10 +316,11 @@ export const GlobalStateProvider = ({
     onSubscriptionData: ({ subscriptionData }) => {
       setTotalItemsReceivedViaSubscription((prev) => prev + 1);
       if (
-        subscriptionData.data.onMutateItem.groupMentions &&
-        subscriptionData.data.onMutateItem.groupMentions.length > 0
+        subscriptionData.data.onMutateItem.groupMentions?.some(
+          ({ isMe }: MentionHandle) => isMe
+        )
       ) {
-        setTotalItemsWithGroupMentionsReceivedViaSubscription(
+        setTotalItemsWithRelevantGroupMentionsReceivedViaSubscription(
           (prev) => prev + 1
         );
       }
@@ -352,7 +354,7 @@ export const GlobalStateProvider = ({
         subscriptionData.data.onClaimItem.groupMentions &&
         subscriptionData.data.onClaimItem.groupMentions.length > 0
       ) {
-        setTotalItemsWithGroupMentionsReceivedViaSubscription(
+        setTotalItemsWithRelevantGroupMentionsReceivedViaSubscription(
           (prev) => prev + 1
         );
       }
@@ -729,7 +731,7 @@ export const GlobalStateProvider = ({
     allSubscriptionClaimedItems,
     allSubscriptionOnSeenItems,
     totalItemsReceivedViaSubscription,
-    totalItemsWithGroupMentionsReceivedViaSubscription,
+    totalItemsWithRelevantGroupMentionsReceivedViaSubscription,
     totalOfMyOwnOnSeenItemsReceivedViaSubscription,
 
     payloadToBeSent,

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -68,7 +68,7 @@ export const Panel = ({
     boundedPositionTranslation,
     unreadFlags,
     setUnreadFlag,
-    totalItemsWithGroupMentionsReceivedViaSubscription,
+    totalItemsWithRelevantGroupMentionsReceivedViaSubscription,
     totalOfMyOwnOnSeenItemsReceivedViaSubscription,
   } = useGlobalStateContext();
 
@@ -102,7 +102,7 @@ export const Panel = ({
   useEffect(() => {
     groupPinboardIdsQuery.refetch();
   }, [
-    totalItemsWithGroupMentionsReceivedViaSubscription,
+    totalItemsWithRelevantGroupMentionsReceivedViaSubscription,
     totalOfMyOwnOnSeenItemsReceivedViaSubscription,
   ]);
 


### PR DESCRIPTION
Following on from https://github.com/guardian/pinboard/pull/367 - we can further reduce calls to `getGroupPinboardIds` to only when the group mention is a group the current user is a member of (otherwise it's not relevant). So now we make use of the existing `isMe` property of the group mention handles which come back on the subscription, to filter the group mentions which could trigger the ensuing call.

✅  TESTED in CODE, by sending a group mention, to a team I'm not a member of and again to one I am a member of and observing that `getGroupPinboardIds` is only called in the latter scenario.