### PR TITLE
fix the local sandbox image thumbnails

### DIFF
--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -114,7 +114,7 @@
       <asset-handle
         data-source="grid"
         data-source-type="original"
-        data-thumbnail="https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/24733ea386c7fcb37496c55cc86e8f1468b9dfcf/817_0_1866_2333/400.jpg"
+        data-thumbnail="https://media.guimcode.co.uk/24733ea386c7fcb37496c55cc86e8f1468b9dfcf/817_0_1866_2333/400.jpg"
         data-embeddable-url="https://media.test.dev-gutools.co.uk/images/24733ea386c7fcb37496c55cc86e8f1468b9dfcf"
       ></asset-handle>
       <br />
@@ -122,7 +122,7 @@
       <asset-handle
         data-source="grid"
         data-source-type="crop"
-        data-thumbnail="https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/24733ea386c7fcb37496c55cc86e8f1468b9dfcf/817_0_1866_2333/400.jpg"
+        data-thumbnail="https://media.guimcode.co.uk/24733ea386c7fcb37496c55cc86e8f1468b9dfcf/817_0_1866_2333/400.jpg"
         data-embeddable-url="https://media.test.dev-gutools.co.uk/images/24733ea386c7fcb37496c55cc86e8f1468b9dfcf?crop=817_0_1866_2333"
       ></asset-handle>
       <br />
@@ -138,7 +138,7 @@
       <asset-handle
         data-source="mam"
         data-source-type="video"
-        data-thumbnail="https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/3a9912b476c90c3f66becae89128adb6894c6331/1393_1066_2607_1467/500.jpg"
+        data-thumbnail="https://media.guimcode.co.uk/3a9912b476c90c3f66becae89128adb6894c6331/1393_1066_2607_1467/500.jpg"
         data-external-url="https://www.youtube.com/embed/smK7tmo5lco?showinfo=0&rel=0"
         data-embeddable-url="https://video.code.dev-gutools.co.uk/videos/e0924f34-f4f3-482c-90c5-01c1aee3f18a"
       ></asset-handle>


### PR DESCRIPTION
following https://github.com/guardian/editorial-tools-platform/pull/849 we can't reference images directly in S3, so fix the local sandbox with CDN equiv