### PR TITLE
special-case "false" as an externalUrl from self-hosted videos

### DIFF
--- a/bootstrapping-lambda/local/index.html
+++ b/bootstrapping-lambda/local/index.html
@@ -142,12 +142,12 @@
         data-external-url="https://www.youtube.com/embed/smK7tmo5lco?showinfo=0&rel=0"
         data-embeddable-url="https://video.code.dev-gutools.co.uk/videos/e0924f34-f4f3-482c-90c5-01c1aee3f18a"
       ></asset-handle>
-      <br/>
+      <br />
       <code>self-hosted-mam-video</code>
       <asset-handle
         data-source="mam"
         data-source-type="video"
-        data-thumbnail="https://uploads.guimcode.co.uk/2025/12/17/Simon_tall_video_test--51234a34-f612-4d9c-bae6-5c2f949066d8-1.0.0000000.jpg"  
+        data-thumbnail="https://uploads.guimcode.co.uk/2025/12/17/Simon_tall_video_test--51234a34-f612-4d9c-bae6-5c2f949066d8-1.0.0000000.jpg"
         data-external-url="false"
         data-embeddable-url="https://video.code.dev-gutools.co.uk/videos/51234a34-f612-4d9c-bae6-5c2f949066d8"
       ></asset-handle>

--- a/client/src/mam/mamVideoDisplay.tsx
+++ b/client/src/mam/mamVideoDisplay.tsx
@@ -5,8 +5,8 @@ import VideoIcon from "../../icons/video.svg";
 import { palette } from "@guardian/source-foundations";
 
 export const MamVideoDisplay = ({ type, payload }: MamVideoPayload) => (
-<React.Fragment>
-    {(payload.externalUrl && payload.externalUrl.toLowerCase() !== 'false') ? (
+  <React.Fragment>
+    {payload.externalUrl && payload.externalUrl.toLowerCase() !== "false" ? (
       <iframe
         css={css`
           pointer-events: none;


### PR DESCRIPTION
## What does this change?

addresses https://github.com/guardian/workflow/issues/1330

Updates the `MamVideoDisplay` component to ignore `externalUrl` with the value "false" and display the `thumbnail` img instead of the `externalUrl` iframe.

As noted in the issue above, MAM sets `externalUrl` to "false" in the asset-handle for pinning self hosted videos, but Pinboard was interpreting this as a relative url ("/false") and setting this as the iframe's `src` - so the preview was a very small frame of the MAM UI.

Also adds an extra pin button to the test page for "self-hosted-mam-video"

## How to test

Deploy to CODE and open a self-hosted video in MAM CODE (eg https://video.code.dev-gutools.co.uk/videos/51234a34-f612-4d9c-bae6-5c2f949066d8).

Click the "add to pinboard" button top right and observe the preview of the video in the chat window
 
## How can we measure success?

When pinning self-hosted video in a conversation, the preview will show the video's thumbnail rather than MAM UI.

This is a short-term fix to address the immediate problem - the aim in future work will be for the MAM video previews in pinboard to include the iconography to indicate the type of video it is (eg loop, you-tube, etc).

## Have we considered potential risks?

Should be safe. 

If the self-hosted video doesn't have a thumbnail, the `MamVideoDisplay` would render a broken image

## Images

|before|after|
|---|---|
|<img width="1142" height="990" alt="Screenshot 2025-12-18 at 15 53 16" src="https://github.com/user-attachments/assets/ae3f7a47-d13c-42a8-ac17-5e2682c1a182" />|<img width="1142" height="990" alt="Screenshot 2025-12-18 at 15 51 32" src="https://github.com/user-attachments/assets/4acb22c2-4c56-47b1-9295-30f780f142ea" />|




## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
