### PR TITLE
patch jws to 4.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7619,7 +7619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
@@ -12634,24 +12634,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwa@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "jwa@npm:2.0.0"
+"jwa@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
   dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
+    buffer-equal-constant-time: "npm:^1.0.1"
     ecdsa-sig-formatter: "npm:1.0.11"
     safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/6baab823b93c038ba1d2a9e531984dcadbc04e9eb98d171f4901b7a40d2be15961a359335de1671d78cb6d987f07cbe5d350d8143255977a889160c4d90fcc3c
+  checksum: 10c0/ab3ebc6598e10dc11419d4ed675c9ca714a387481466b10e8a6f3f65d8d9c9237e2826f2505280a739cf4cbcf511cb288eeec22b5c9c63286fc5a2e4f97e78cf
   languageName: node
   linkType: hard
 
 "jws@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jws@npm:4.0.0"
+  version: 4.0.1
+  resolution: "jws@npm:4.0.1"
   dependencies:
-    jwa: "npm:^2.0.0"
+    jwa: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/f1ca77ea5451e8dc5ee219cb7053b8a4f1254a79cb22417a2e1043c1eb8a569ae118c68f24d72a589e8a3dd1824697f47d6bd4fb4bebb93a3bdf53545e721661
+  checksum: 10c0/6be1ed93023aef570ccc5ea8d162b065840f3ef12f0d1bb3114cade844de7a357d5dc558201d9a65101e70885a6fa56b17462f520e6b0d426195510618a154d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Patches the jws package to 4.0.1 to address https://github.com/advisories/GHSA-869p-cjfg-cm3x

jws is used in notifications-lambda and users-refresher-lambda
```
$ npm ls jws
editorial-tools-pinboard@1.0.0 /Users/david_blatcher/code/pinboard
├─┬ notifications-lambda@1.0.0 -> ./notifications-lambda
│ └─┬ web-push@3.5.0
│   └── jws@4.0.1
└─┬ users-refresher-lambda@1.0.0 -> ./users-refresher-lambda
  └─┬ @googleapis/admin@9.0.1
    └─┬ googleapis-common@6.0.4
      └─┬ google-auth-library@8.8.0
        ├─┬ gtoken@6.1.2
        │ └── jws@4.0.1 deduped
        └── jws@4.0.1 deduped
```


## How to test

Deploy to CODE
 - to send notifications-lambda - should be sufficient to check messages can still be send and recieved from the chat
 - users-refresher-lambda runs on a daily schedule - the readme includes notes on how to manually trigger a call to apply an update to the user list, we could do this for testing

[have deployed to CODE and performed both checks]



