### PR TITLE
Add Sentry extras for payload parse failure

### DIFF
--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -23,9 +23,13 @@ export const AssetView = ({ items }: AssetViewProps) => {
       const payloadAndType = buildPayloadAndType(item.type, payload);
       if (!payloadAndType) {
         Sentry.captureException(
-          new Error(
-            `Failed to parse payload with type=${item.type}, payload=${item.payload}`
-          )
+          new Error(`Failed to parse payload with type=${item.type}`),
+          {
+            extra: {
+              payloadType: item.type,
+              payload,
+            },
+          }
         );
         return accumulator;
       }

--- a/client/src/types/PayloadAndType.ts
+++ b/client/src/types/PayloadAndType.ts
@@ -107,7 +107,13 @@ export const maybeConstructPayloadAndType = (
 
   if (!payloadAndType) {
     Sentry.captureException(
-      new Error(`Failed to parse payload with type=${type}, payload=${payload}`)
+      new Error(`Failed to parse payload with type=${type}`),
+      {
+        extra: {
+          payloadType: type,
+          payload,
+        },
+      }
     );
   }
 


### PR DESCRIPTION
## What does this change?

We’re currently seeing [some of these errors in Sentry](https://the-guardian.sentry.io/issues/7002220209/?alert_rule_id=46712&alert_timestamp=1774534604821&alert_type=email&notification_uuid=3f1f7da3-5686-4ebd-935a-a2392676a987&project=26737&referrer=alert_email), and because the payload is just in the error text it’s cut off by Sentry before it shows useful data. I think switching to an extra like this will make sure Sentry captures the whole data and shows it to us in the UI, which should help with debugging these errors.

## How has this change been tested?

This change has not been tested, but typescript appears to be happy so I think at worst I’m wrong about the extra data and the next couple of errors show even less helpful data. In that case we can revert.