### PR TITLE
Bump ws to 8.21.0 and 7.5.11

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15480,8 +15480,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^7.3.1":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -15490,13 +15490,13 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  checksum: 10c0/7972670b676fb1ccba73b0899ca3c2e04e8c2075629c2614cced7f556536f96a672bbf4619fc5a06c8b8720bb839a47ca88c69c95dc14c9c61a99fbecba1c866
   languageName: node
   linkType: hard
 
 "ws@npm:^8.17.1, ws@npm:^8.18.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -15505,7 +15505,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Responding to dependabot alert: https://github.com/guardian/pinboard/security/dependabot/188

`yarn why ws` gives following output:

```
├─ @graphql-tools/executor-graphql-ws@npm:1.3.7
│  └─ ws@npm:8.21.0 (via npm:^8.17.1)
│
├─ @graphql-tools/executor-graphql-ws@npm:1.3.7 [dce64]
│  └─ ws@npm:8.21.0 [dce64] (via npm:^8.17.1 [dce64])
│
├─ @graphql-tools/executor-legacy-ws@npm:1.1.8
│  └─ ws@npm:8.21.0 (via npm:^8.17.1)
│
├─ @graphql-tools/executor-legacy-ws@npm:1.1.8 [dce64]
│  └─ ws@npm:8.21.0 [dce64] (via npm:^8.17.1 [dce64])
│
├─ @graphql-tools/url-loader@npm:8.0.21
│  └─ ws@npm:8.21.0 (via npm:^8.17.1)
│
├─ @graphql-tools/url-loader@npm:8.0.21 [3fca7]
│  └─ ws@npm:8.21.0 [dce64] (via npm:^8.17.1 [dce64])
│
├─ webpack-bundle-analyzer@npm:4.5.0
│  └─ ws@npm:7.5.11 [82010] (via npm:^7.3.1 [82010])
│
├─ webpack-dev-server@npm:5.2.3
│  └─ ws@npm:8.21.0 (via npm:^8.18.0)
│
└─ webpack-dev-server@npm:5.2.3 [65614]
└─ ws@npm:8.21.0 [dce64] (via npm:^8.17.1 [dce64])
```

(`8.21.0` and `7.5.11` are patched versions)

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Will deploy to CODE and do a general smoke test.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
