### PR TITLE
bump tar override

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,7 @@
     "@aws-cdk/aws-appsync-alpha": "2.54.0-alpha.0",
     "@guardian/cdk": "^62.1.1",
     "aws-cdk": "^2.1127.0",
-    "aws-cdk-lib": "^2.260.0",
+    "aws-cdk-lib": "^2.246.0",
     "constructs": "10.4.3",
     "ts-node": "9.0.0"
   }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,7 @@
     "@aws-cdk/aws-appsync-alpha": "2.54.0-alpha.0",
     "@guardian/cdk": "^62.1.1",
     "aws-cdk": "^2.1127.0",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "^2.260.0",
     "constructs": "10.4.3",
     "ts-node": "9.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "resolutions": {
     "cdk@1.0.0/cross-spawn": "^7.0.5",
     "client@1.0.0/cross-spawn": "^7.0.5",
-    "tar": "^7.5.11"
+    "tar": "^7.5.22"
   },
   "lint-staged": {
     "**/*.{ts, tsx}": "eslint --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,26 +109,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-api@npm:^2.2.6":
-  version: 2.3.0
-  resolution: "@aws-cdk/cloud-assembly-api@npm:2.3.0"
+"@aws-cdk/cloud-assembly-api@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.5"
   dependencies:
-    json-source-map: "npm:^0.6.1"
     jsonschema: "npm:^1.5.0"
-    semver: "npm:^7.8.5"
+    semver: "npm:^7.8.0"
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": ">=54.12.0"
-  checksum: 10c0/a720cfda736db119e6db510f58d213d0c46041af7d458f58b501b032f6446c6f65861ef9f283b3b41b3cb60dfd53a951530f0c38acca9c4d6e63b5646f6c5fb0
+    "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+  checksum: 10c0/82b725a9bfbdfb0e6256047450d7df260f1b08b16db2a8759e373aa7bb33dd6f7f67e857804efbb577a619097b2b1b94f3f088506dae6de6fbdaad41043f24b6
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:^54.11.0":
-  version: 54.14.0
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:54.14.0"
+"@aws-cdk/cloud-assembly-schema@npm:^54.0.0":
+  version: 54.3.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:54.3.0"
   dependencies:
     jsonschema: "npm:^1.5.0"
-    semver: "npm:^7.8.5"
-  checksum: 10c0/4d0e45b18e6c865b37db22685dfa9770250e72a2d11a53d2ef624c55128b81137f62cf0d96ad932b0c0affbbc308b96eeb79dd16313936dd164e7dc5d63ce370
+    semver: "npm:^7.8.4"
+  checksum: 10c0/51aca17abbc9bcb48a39f7c24e71b54ec075ca606bf6f9f2f68cf3bd922a8971e6cf5074ffc526a02c47c215474c8a890e3e315814ba7c1e6882c7cdb9a7010e
   languageName: node
   linkType: hard
 
@@ -899,13 +898,6 @@ __metadata:
     fast-xml-parser: "npm:5.7.3"
     tslib: "npm:^2.6.2"
   checksum: 10c0/6544aee8bd653252da337dd83482309a5fd46159a8e50280795708c7cf9194c19bf63a75e086ad764ec52fbc239857a03e7ae238a213f5dfa4aa496cbf938f1d
-  languageName: node
-  linkType: hard
-
-"@aws/cloudformation-validate@npm:1.5.1-beta":
-  version: 1.5.1-beta
-  resolution: "@aws/cloudformation-validate@npm:1.5.1-beta"
-  checksum: 10c0/aebf7c2922f1ddc8afb74e9aae4e9f101869325153cfc25fcdea6b94bce755c9e8712cdae5fd2c8502caa707a82a32c6c08128b03eb60dcb0f35ffe3d7224fcd
   languageName: node
   linkType: hard
 
@@ -5733,28 +5725,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:^2.260.0":
-  version: 2.262.1
-  resolution: "aws-cdk-lib@npm:2.262.1"
+"aws-cdk-lib@npm:^2.246.0":
+  version: 2.259.0
+  resolution: "aws-cdk-lib@npm:2.259.0"
   dependencies:
     "@aws-cdk/asset-awscli-v1": "npm:2.2.282"
     "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.2"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.6"
-    "@aws-cdk/cloud-assembly-schema": "npm:^54.11.0"
-    "@aws/cloudformation-validate": "npm:1.5.1-beta"
+    "@aws-cdk/cloud-assembly-api": "npm:^2.2.5"
+    "@aws-cdk/cloud-assembly-schema": "npm:^54.0.0"
     "@balena/dockerignore": "npm:^1.0.2"
     case: "npm:1.6.3"
-    fs-extra: "npm:^11.3.6"
+    fs-extra: "npm:^11.3.5"
     ignore: "npm:^5.3.2"
     jsonschema: "npm:^1.5.0"
     mime-types: "npm:^2.1.35"
     minimatch: "npm:^10.2.5"
     punycode: "npm:^2.3.1"
-    semver: "npm:^7.8.5"
+    semver: "npm:^7.8.1"
+    table: "npm:^6.9.0"
     yaml: "npm:1.10.3"
   peerDependencies:
     constructs: ^10.5.0
-  checksum: 10c0/3e50e4c8dc7213fb1288a7e9633f045f995e048a4654dc1b6d44358259e5fb1dde3b8738845e5a69bf5b57232150fc8dcb9b3690ee74166cc13cc0a21ef7d6f3
+  checksum: 10c0/1aaf83ccf22ade37ba2316309292ae8faf55cee5f01cfcc0388180646678a2edcc0dfaa94a11efd50b5b75a41b0125c1d2037f3f61864289321716b755cf1445
   languageName: node
   linkType: hard
 
@@ -6352,7 +6344,7 @@ __metadata:
     "@aws-cdk/aws-appsync-alpha": "npm:2.54.0-alpha.0"
     "@guardian/cdk": "npm:^62.1.1"
     aws-cdk: "npm:^2.1127.0"
-    aws-cdk-lib: "npm:^2.260.0"
+    aws-cdk-lib: "npm:^2.246.0"
     constructs: "npm:10.4.3"
     ts-node: "npm:9.0.0"
   languageName: unknown
@@ -8716,14 +8708,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.3.6":
-  version: 11.4.0
-  resolution: "fs-extra@npm:11.4.0"
+"fs-extra@npm:^11.3.5":
+  version: 11.3.5
+  resolution: "fs-extra@npm:11.3.5"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
-  checksum: 10c0/1e311eca820a12d3d795f2043dcd5628d017f4d21e634f3f9ef314ae68bee9979758262fb9cb35ffa6f26454c3fffe8b15558733e91e8fc729b07b10bb98d8b6
+  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 
@@ -10902,13 +10894,6 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
-  languageName: node
-  linkType: hard
-
-"json-source-map@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "json-source-map@npm:0.6.1"
-  checksum: 10c0/9fe819f7dfc1407caf8e36246f18376eb511b969954d457b251dfb506df74544cefc0c368f64474b512956eeb37807e03045332a9712ddd14b836d54debe03c3
   languageName: node
   linkType: hard
 
@@ -13372,21 +13357,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3":
+"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.8.0, semver@npm:^7.8.1, semver@npm:^7.8.4":
   version: 7.8.4
   resolution: "semver@npm:7.8.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.8.5":
-  version: 7.8.5
-  resolution: "semver@npm:7.8.5"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -14245,7 +14221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.0.4":
+"table@npm:^6.0.4, table@npm:^6.9.0":
   version: 6.9.0
   resolution: "table@npm:6.9.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14241,16 +14241,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:^7.5.22":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,25 +109,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-api@npm:^2.2.5":
-  version: 2.2.5
-  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.5"
+"@aws-cdk/cloud-assembly-api@npm:^2.2.6":
+  version: 2.3.0
+  resolution: "@aws-cdk/cloud-assembly-api@npm:2.3.0"
   dependencies:
+    json-source-map: "npm:^0.6.1"
     jsonschema: "npm:^1.5.0"
-    semver: "npm:^7.8.0"
+    semver: "npm:^7.8.5"
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
-  checksum: 10c0/82b725a9bfbdfb0e6256047450d7df260f1b08b16db2a8759e373aa7bb33dd6f7f67e857804efbb577a619097b2b1b94f3f088506dae6de6fbdaad41043f24b6
+    "@aws-cdk/cloud-assembly-schema": ">=54.12.0"
+  checksum: 10c0/a720cfda736db119e6db510f58d213d0c46041af7d458f58b501b032f6446c6f65861ef9f283b3b41b3cb60dfd53a951530f0c38acca9c4d6e63b5646f6c5fb0
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:^54.0.0":
-  version: 54.3.0
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:54.3.0"
+"@aws-cdk/cloud-assembly-schema@npm:^54.11.0":
+  version: 54.14.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:54.14.0"
   dependencies:
     jsonschema: "npm:^1.5.0"
-    semver: "npm:^7.8.4"
-  checksum: 10c0/51aca17abbc9bcb48a39f7c24e71b54ec075ca606bf6f9f2f68cf3bd922a8971e6cf5074ffc526a02c47c215474c8a890e3e315814ba7c1e6882c7cdb9a7010e
+    semver: "npm:^7.8.5"
+  checksum: 10c0/4d0e45b18e6c865b37db22685dfa9770250e72a2d11a53d2ef624c55128b81137f62cf0d96ad932b0c0affbbc308b96eeb79dd16313936dd164e7dc5d63ce370
   languageName: node
   linkType: hard
 
@@ -898,6 +899,13 @@ __metadata:
     fast-xml-parser: "npm:5.7.3"
     tslib: "npm:^2.6.2"
   checksum: 10c0/6544aee8bd653252da337dd83482309a5fd46159a8e50280795708c7cf9194c19bf63a75e086ad764ec52fbc239857a03e7ae238a213f5dfa4aa496cbf938f1d
+  languageName: node
+  linkType: hard
+
+"@aws/cloudformation-validate@npm:1.5.1-beta":
+  version: 1.5.1-beta
+  resolution: "@aws/cloudformation-validate@npm:1.5.1-beta"
+  checksum: 10c0/aebf7c2922f1ddc8afb74e9aae4e9f101869325153cfc25fcdea6b94bce755c9e8712cdae5fd2c8502caa707a82a32c6c08128b03eb60dcb0f35ffe3d7224fcd
   languageName: node
   linkType: hard
 
@@ -5725,28 +5733,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:^2.246.0":
-  version: 2.259.0
-  resolution: "aws-cdk-lib@npm:2.259.0"
+"aws-cdk-lib@npm:^2.260.0":
+  version: 2.262.1
+  resolution: "aws-cdk-lib@npm:2.262.1"
   dependencies:
     "@aws-cdk/asset-awscli-v1": "npm:2.2.282"
     "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.2"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.5"
-    "@aws-cdk/cloud-assembly-schema": "npm:^54.0.0"
+    "@aws-cdk/cloud-assembly-api": "npm:^2.2.6"
+    "@aws-cdk/cloud-assembly-schema": "npm:^54.11.0"
+    "@aws/cloudformation-validate": "npm:1.5.1-beta"
     "@balena/dockerignore": "npm:^1.0.2"
     case: "npm:1.6.3"
-    fs-extra: "npm:^11.3.5"
+    fs-extra: "npm:^11.3.6"
     ignore: "npm:^5.3.2"
     jsonschema: "npm:^1.5.0"
     mime-types: "npm:^2.1.35"
     minimatch: "npm:^10.2.5"
     punycode: "npm:^2.3.1"
-    semver: "npm:^7.8.1"
-    table: "npm:^6.9.0"
+    semver: "npm:^7.8.5"
     yaml: "npm:1.10.3"
   peerDependencies:
     constructs: ^10.5.0
-  checksum: 10c0/1aaf83ccf22ade37ba2316309292ae8faf55cee5f01cfcc0388180646678a2edcc0dfaa94a11efd50b5b75a41b0125c1d2037f3f61864289321716b755cf1445
+  checksum: 10c0/3e50e4c8dc7213fb1288a7e9633f045f995e048a4654dc1b6d44358259e5fb1dde3b8738845e5a69bf5b57232150fc8dcb9b3690ee74166cc13cc0a21ef7d6f3
   languageName: node
   linkType: hard
 
@@ -6344,7 +6352,7 @@ __metadata:
     "@aws-cdk/aws-appsync-alpha": "npm:2.54.0-alpha.0"
     "@guardian/cdk": "npm:^62.1.1"
     aws-cdk: "npm:^2.1127.0"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:^2.260.0"
     constructs: "npm:10.4.3"
     ts-node: "npm:9.0.0"
   languageName: unknown
@@ -8708,14 +8716,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.3.5":
-  version: 11.3.5
-  resolution: "fs-extra@npm:11.3.5"
+"fs-extra@npm:^11.3.6":
+  version: 11.4.0
+  resolution: "fs-extra@npm:11.4.0"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
-  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
+  checksum: 10c0/1e311eca820a12d3d795f2043dcd5628d017f4d21e634f3f9ef314ae68bee9979758262fb9cb35ffa6f26454c3fffe8b15558733e91e8fc729b07b10bb98d8b6
   languageName: node
   linkType: hard
 
@@ -10894,6 +10902,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "json-source-map@npm:0.6.1"
+  checksum: 10c0/9fe819f7dfc1407caf8e36246f18376eb511b969954d457b251dfb506df74544cefc0c368f64474b512956eeb37807e03045332a9712ddd14b836d54debe03c3
   languageName: node
   linkType: hard
 
@@ -13357,12 +13372,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.8.0, semver@npm:^7.8.1, semver@npm:^7.8.4":
+"semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3":
   version: 7.8.4
   resolution: "semver@npm:7.8.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -14221,7 +14245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.0.4, table@npm:^6.9.0":
+"table@npm:^6.0.4":
   version: 6.9.0
   resolution: "table@npm:6.9.0"
   dependencies:


### PR DESCRIPTION
## What does this change?

bump tar override version to address:

- https://github.com/advisories/GHSA-8x88-c5mf-7j5w
- http://github.com/advisories/GHSA-23hp-3jrh-7fpw

## How has this change been tested?

[deployed to code](https://riffraff.gutools.co.uk/deployment/view/f69590d4-a33f-4173-b8ca-a6f549850dae), smoke tested - was able to send messages between composer and workflow 

## How can we measure success?

vulnerabilities down
